### PR TITLE
Allow overriding of parent container's lifecycle to transient in the nested container

### DIFF
--- a/Source/StructureMap/Configuration/DSL/Expressions/CreatePluginFamilyExpression.cs
+++ b/Source/StructureMap/Configuration/DSL/Expressions/CreatePluginFamilyExpression.cs
@@ -208,6 +208,15 @@ namespace StructureMap.Configuration.DSL.Expressions
             return lifecycleIs(InstanceScope.Singleton);
         }
 
+        /// <summary>
+        /// Convenience method to mark a PluginFamily as a Transient
+        /// </summary>
+        /// <returns></returns>
+        public CreatePluginFamilyExpression<PLUGINTYPE> Transient()
+        {
+            return lifecycleIs(InstanceScope.Transient);
+        }
+
         private CreatePluginFamilyExpression<PLUGINTYPE> lifecycleIs(InstanceScope lifecycle)
         {
             _alterations.Add(family => family.SetScopeTo(lifecycle));

--- a/Source/StructureMap/Graph/PluginFamily.cs
+++ b/Source/StructureMap/Graph/PluginFamily.cs
@@ -22,7 +22,7 @@ namespace StructureMap.Graph
         private ILifecycle _lifecycle;
         private PluginGraph _parent;
 
-        public PluginFamily(Type pluginType)
+    	public PluginFamily(Type pluginType)
             : this(pluginType, new PluginGraph())
         {
         }
@@ -36,7 +36,9 @@ namespace StructureMap.Graph
 
         }
 
-        public PluginGraph Parent { get { return _parent; } set { _parent = value; } }
+    	public InstanceScope? Scope { get; private set; }
+
+    	public PluginGraph Parent { get { return _parent; } set { _parent = value; } }
         public IEnumerable<Instance> Instances { get { return _instances.GetAll(); } }
 
         #region IPluginFamily Members
@@ -48,7 +50,8 @@ namespace StructureMap.Graph
 
         public void SetScopeTo(InstanceScope scope)
         {
-            if (scope == InstanceScope.Transient)
+        	Scope = scope;
+        	if (scope == InstanceScope.Transient)
             {
                 _lifecycle = null;
                 return;

--- a/Source/StructureMap/InstanceFactory.cs
+++ b/Source/StructureMap/InstanceFactory.cs
@@ -98,8 +98,9 @@ namespace StructureMap
             {
                 _lifecycle = family.Lifecycle;
             }
-            else if (_lifecycle != null && family.Lifecycle != null &&
-                     !_lifecycle.GetType().Equals(family.Lifecycle.GetType()))
+            else if ((family.Lifecycle != null &&
+                     !_lifecycle.GetType().Equals(family.Lifecycle.GetType())) || 
+				((family.Scope != null) && (family.Scope.Value.ToString() != _lifecycle.ToName())))
             {
                 // TODO:  Might need to clear out the existing policy when it's ejected
                 _lifecycle = family.Lifecycle;


### PR DESCRIPTION
Hit a problem where the parent container's lifecycle for a plugin was set to Hybrid, but in the nested container I wanted to have it as Transient (and do For<Foo>().Use(myBuiltObj));

The plugin graph import piece couldn't determine between the child instance unconfigured, or actually set to Transient (by doing LifecycleIs(null)).

I fixed it with a bit of a hack, but really couldn't do anything else since transient lifecycle is not an actual ILifecycle.
