### PR TITLE
Bugfix for open generic types with constraints

### DIFF
--- a/Source/StructureMap.Testing/Bugs/OpenGenericWithConstraints.cs
+++ b/Source/StructureMap.Testing/Bugs/OpenGenericWithConstraints.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using System.Linq;
+using NUnit.Framework.SyntaxHelpers;
+
+namespace StructureMap.Testing.Bugs
+{
+    public class ClosedGenericForStruct<T>: IAmOpenGeneric<T>
+        where T: struct {}
+
+    public class ClosedGenericForEnumerable<T>: IAmOpenGeneric<T>
+        where T: IEnumerable {}
+
+    public struct EnumerableStruct: IEnumerable
+    {
+        #region IEnumerable Members
+
+        public IEnumerator GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+
+    [TestFixture]
+    public class OpenGenericWithConstraints
+    {
+        [Test]
+        public void RegisterTwoInheritorsWithDifferentTypeConstraints()
+        {
+            var container = new Container(x => {
+                                              x.Scan(y => y.TheCallingAssembly());
+                                              x.For(typeof(IAmOpenGeneric<>)).Add(typeof(ClosedGenericForEnumerable<>));
+                                              x.For(typeof(IAmOpenGeneric<>)).Add(typeof(ClosedGenericForStruct<>));
+                                          });
+            container.GetInstance<IAmOpenGeneric<int>>().ShouldBeOfType<ClosedGenericForStruct<int>>();
+            container.GetInstance<IAmOpenGeneric<ArrayList>>().ShouldBeOfType<ClosedGenericForEnumerable<ArrayList>>();
+
+            IList<IAmOpenGeneric<EnumerableStruct>> amOpenGenerics = container.GetAllInstances<IAmOpenGeneric<EnumerableStruct>>();
+            amOpenGenerics.Single(x => x.GetType() == typeof(ClosedGenericForStruct<EnumerableStruct>));
+            amOpenGenerics.Single(x => x.GetType() == typeof(ClosedGenericForEnumerable<EnumerableStruct>));
+            Assert.That(amOpenGenerics.Count, Is.EqualTo(2));
+        }
+    }
+}

--- a/Source/StructureMap.Testing/StructureMap.Testing.csproj
+++ b/Source/StructureMap.Testing/StructureMap.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
-    <ProductVersion>9.0.30729</ProductVersion>
+    <ProductVersion>9.0.21022</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{63C2742D-B6E2-484F-AFDB-346873075C5E}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -198,6 +198,7 @@
     <Compile Include="Bugs\InjectByFuncWithNoPublicConstructors.cs" />
     <Compile Include="Bugs\LambdaCreatesNullBugTester.cs" />
     <Compile Include="Bugs\MixedConfigureAndInitializeMissingInstanceProblem.cs" />
+    <Compile Include="Bugs\OpenGenericWithConstraints.cs" />
     <Compile Include="Bugs\ScanIndexerBugTester.cs" />
     <Compile Include="Bugs\SingletonShouldBeLazy.cs" />
     <Compile Include="Bugs\SpecifyScopeInConfigureTester.cs" />

--- a/Source/StructureMap/InstanceFactory.cs
+++ b/Source/StructureMap/InstanceFactory.cs
@@ -56,15 +56,18 @@ namespace StructureMap
 
         public static InstanceFactory CreateFactoryForType(Type concreteType, ProfileManager profileManager)
         {
-            var family = new PluginFamily(concreteType);
+            return CreateFactoryForFamily(new PluginFamily(concreteType), profileManager);
+        }
+
+        public static InstanceFactory CreateFactoryForFamily(PluginFamily family, ProfileManager profileManager)
+        {
             family.Seal();
 
             var factory = new InstanceFactory(family);
 
             Instance instance = family.GetDefaultInstance();
-            if (instance != null)
-            {
-                profileManager.SetDefault(concreteType, instance);
+            if(instance != null) {
+                profileManager.SetDefault(family.PluginType, instance);
             }
 
             return factory;

--- a/Source/StructureMap/Pipeline/ConstructorInstance.cs
+++ b/Source/StructureMap/Pipeline/ConstructorInstance.cs
@@ -253,23 +253,26 @@ namespace StructureMap.Pipeline
 
         public override Instance CloseType(Type[] types)
         {
-            if (_plugin.PluggedType.IsOpenGeneric())
-            {
-                Type closedType = _plugin.PluggedType.MakeGenericType(types);
-                var closedInstance = new ConstructorInstance(closedType);
+            if(!_plugin.PluggedType.IsOpenGeneric())
+                return null;
 
-                _dependencies.Each((key, i) =>
-                {
-                    if (i.CopyAsIsWhenClosingInstance)
-                    {
-                        closedInstance.SetChild(key, i);
-                    }
-                });
-
-                return closedInstance;
+            Type closedType;
+            try {
+                closedType = _plugin.PluggedType.MakeGenericType(types);
+            }
+            catch {
+                return null;
             }
 
-            return null;
+            var closedInstance = new ConstructorInstance(closedType);
+
+            _dependencies.Each((key, i) => {
+                                   if(i.CopyAsIsWhenClosingInstance) {
+                                       closedInstance.SetChild(key, i);
+                                   }
+                               });
+
+            return closedInstance;
         }
 
         public override string ToString()

--- a/Source/StructureMap/PipelineGraph.cs
+++ b/Source/StructureMap/PipelineGraph.cs
@@ -159,7 +159,7 @@ namespace StructureMap
             if (pluggedType.IsGenericType)
             {
                 PluginFamily family = _genericsGraph.CreateTemplatedFamily(pluggedType, _profileManager);
-                if (family != null) return new InstanceFactory(family);
+                if (family != null) return InstanceFactory.CreateFactoryForFamily(family, _profileManager);
             }
 
             return InstanceFactory.CreateFactoryForType(pluggedType, _profileManager);


### PR DESCRIPTION
Suppose we have open generic interface and two open generic class implementations. Each of the classes has its own type constraints.
In this case requesting for interface with specified type parameter which breaks at least one of type constraints of implementing classes will cause an exception.

Which in code means the following:
```public interface IOpenInterface<T> { }
public class ClosedGenericForStruct<T>: IOpenInterface<T> where T: struct { }
public class ClosedGenericForEnumerable<T>: IOpenInterface<T> where T: IEnumerable { }
....
configuratorExpression.For(typeof(IOpenInterface<>)).Add(typeof(ClosedGenericForEnumerable<>));
configuratorExpression.For(typeof(IOpenInterface<>)).Add(typeof(ClosedGenericForStruct<>));
....
container.GetInstance<IOpenInterface<int>>(); // theoretically should be ClosedGenericForStruct<int>, but practically it throws ArgumentException

```
```
