### PR TITLE
bug: primitive fields that are set in the constructor are overwritten via setters

### DIFF
--- a/Source/StructureMap.Testing/Bugs/OverwritingOfPrimitiveProperties.cs
+++ b/Source/StructureMap.Testing/Bugs/OverwritingOfPrimitiveProperties.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using StructureMap.Testing.TestData;
+
+namespace StructureMap.Testing.Bugs
+{
+    [TestFixture]
+    public class OverwritingOfPrimitiveProperties
+    {
+        public const string XML_FILENAME = "BUG_OverwritingOfPrimitiveProperties.xml";
+
+        [SetUp]
+        public void SetUp()
+        {
+            DataMother.WriteDocument(XML_FILENAME);
+        }
+
+        [Test]
+        public void Test()
+        {   
+            ObjectFactory.Initialize(x =>
+            {
+                x.AddConfigurationFromXmlFile(XML_FILENAME);
+            });
+
+            IFooWithPrimitives foo = ObjectFactory.GetInstance<IFooWithPrimitives>();
+            Assert.IsNotNull(foo);
+            Assert.AreEqual("Test123", foo.TestValue);
+            Assert.IsTrue(foo.IsTest);
+        }
+    }
+
+    public interface IFooWithPrimitives
+    {
+        bool IsTest { get; }
+        string TestValue { get; }
+    }
+
+    public class FooWithPrimitives : IFooWithPrimitives
+    {
+        public FooWithPrimitives(String name) 
+        {
+            _testString = name;
+        }
+
+        private string _testString = string.Empty;
+        private bool _testBool = true;
+
+        public bool IsTest
+        {
+            get { return _testBool; }
+            set { _testBool = value; }
+        }
+
+        public string TestValue
+        {
+            get { return _testString; }
+            set { _testString = value; }
+        }
+
+    }
+}

--- a/Source/StructureMap.Testing/StructureMap.Testing.csproj
+++ b/Source/StructureMap.Testing/StructureMap.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
-    <ProductVersion>9.0.21022</ProductVersion>
+    <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{63C2742D-B6E2-484F-AFDB-346873075C5E}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -199,6 +199,7 @@
     <Compile Include="Bugs\LambdaCreatesNullBugTester.cs" />
     <Compile Include="Bugs\MixedConfigureAndInitializeMissingInstanceProblem.cs" />
     <Compile Include="Bugs\OpenGenericWithConstraints.cs" />
+    <Compile Include="Bugs\OverwritingOfPrimitiveProperties.cs" />
     <Compile Include="Bugs\ScanIndexerBugTester.cs" />
     <Compile Include="Bugs\SingletonShouldBeLazy.cs" />
     <Compile Include="Bugs\SpecifyScopeInConfigureTester.cs" />
@@ -486,6 +487,7 @@
     <Content Include="Examples\AddRegistryInXml.xml" />
     <Content Include="Sample.xml" />
     <Content Include="TestData\ProfileSample.xml" />
+    <EmbeddedResource Include="TestData\BUG_OverwritingOfPrimitiveProperties.xml" />
     <EmbeddedResource Include="TestData\ShortInstance.xml" />
     <EmbeddedResource Include="TestData\DefaultInstance.xml" />
   </ItemGroup>

--- a/Source/StructureMap.Testing/TestData/BUG_OverwritingOfPrimitiveProperties.xml
+++ b/Source/StructureMap.Testing/TestData/BUG_OverwritingOfPrimitiveProperties.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<StructureMap>
+
+  <PluginFamily Type="StructureMap.Testing.Bugs.IFooWithPrimitives" Assembly="StructureMap.Testing" DefaultKey="TEST">
+    <Instance Key="TEST" Scope="Singleton" PluggedType="StructureMap.Testing.Bugs.FooWithPrimitives, StructureMap.Testing">
+      <Property Name="name" Value="Test123" />
+    </Instance>
+  </PluginFamily>
+
+</StructureMap>

--- a/Source/StructureMap/Pipeline/ConstructorInstance.cs
+++ b/Source/StructureMap/Pipeline/ConstructorInstance.cs
@@ -87,7 +87,7 @@ namespace StructureMap.Pipeline
         public bool HasProperty(string propertyName, BuildSession session)
         {
             // TODO -- richer behavior
-            return _dependencies.Has(propertyName);
+            return _dependencies.Has(propertyName) && !(_dependencies[propertyName] is NullInstance);
         }
 
         Instance IStructuredInstance.GetChild(string name)


### PR DESCRIPTION
This is a fix for the following issue -> https://github.com/structuremap/structuremap/issues/9

Includes a unit test.
