### PR TITLE
Fix for ObjectFactory.EjectAllInstancesOf<T>

### DIFF
--- a/Source/StructureMap/Pipeline/HttpLifecycleBase.cs
+++ b/Source/StructureMap/Pipeline/HttpLifecycleBase.cs
@@ -15,7 +15,10 @@ namespace StructureMap.Pipeline
 
         public void EjectAll()
         {
-            _http.EjectAll();
+            if (HttpContextLifecycle.HasContext())
+            {
+                _http.EjectAll();
+            }
             _nonHttp.EjectAll();
         }
 


### PR DESCRIPTION
Very tiny fix that was suggested in Issue #10, which I needed, so I forked!
