### PR TITLE
Add Assembly Version Number to HttpContextLifecycle ITEM_NAME to avoid version conflicts

### DIFF
--- a/Source/StructureMap/Pipeline/HttpContextLifecycle.cs
+++ b/Source/StructureMap/Pipeline/HttpContextLifecycle.cs
@@ -1,11 +1,12 @@
 using System.Collections;
+using System.Reflection;
 using System.Web;
 
 namespace StructureMap.Pipeline
 {
     public class HttpContextLifecycle : ILifecycle
     {
-        public static readonly string ITEM_NAME = "STRUCTUREMAP-INSTANCES";
+        public static readonly string ITEM_NAME = string.Format("STRUCTUREMAP-INSTANCES-{0}", Assembly.GetExecutingAssembly().GetName().Version);
 
 
         public void EjectAll()


### PR DESCRIPTION
If two assemblies in the same appdomain use different versions of Structuremap and they both use HttpContextLifecycle for any of their dependencies, it is likely to receive the following error:

System.InvalidCastException: Unable to cast object of type 'StructureMap.Pipeline.MainObjectCache' to type 'StructureMap.Pipeline.IObjectCache'.

This is because both versions share the same cache in HttpContext.Items since the HttpContextLifecycle maintains a static key to the HttpContext.Items called "STRUCTUREMAP-INSTANCES",  So when the assembly that did not originally Add the cache tries to retrieve the cache casting it to IObjectCache, a InvalidCastException is raised since the IObjectContext of that assembly is different than the IObjectCache of the other assembly.

Adding the version to the cache key ensures that the cache of different Structuremap versions are isolated.
