### PR TITLE
Fixed NullReferenceException if Namespace is null

### DIFF
--- a/Source/StructureMap.Testing/Graph/AssemblyScannerTester.cs
+++ b/Source/StructureMap.Testing/Graph/AssemblyScannerTester.cs
@@ -114,6 +114,13 @@ namespace StructureMap.Testing.Graph
         }
 
         [Test]
+        public void class_outside_namespace_doesnt_match_any_namespace_check()
+        {
+            typeof(class_outside_namespace).IsInNamespace("blah").ShouldBeFalse();
+            typeof(class_outside_namespace).IsInNamespace("StructureMap").ShouldBeFalse();
+        }
+
+        [Test]
         public void Only_scan_for_registries_ignores_attributes()
         {
             Scan(x =>
@@ -424,4 +431,9 @@ namespace StructureMap.Testing.Graph
                 .ShouldBeOfType<SiteController>();
         }
     }
+}
+
+public class class_outside_namespace
+{
+    
 }

--- a/Source/StructureMap/TypeExtensions.cs
+++ b/Source/StructureMap/TypeExtensions.cs
@@ -74,7 +74,7 @@ namespace StructureMap
 
             public static bool IsInNamespace(this Type type, string nameSpace)
             {
-                return type.Namespace.StartsWith(nameSpace);
+                return type.Namespace != null && type.Namespace.StartsWith(nameSpace);
             }
 
             public static ReferencedInstance GetReferenceTo(this Type type)


### PR DESCRIPTION
The IsInNamespace extension method didn't check if type.Namespace was null, resulting in a NRE when processing third party assemblies which contained types outside a namespace (but had other types we needed to register). Added a test to cover the scenario.
