### PR TITLE
Fixed iteration of _scanner which causes issues in .Net 4.5 not triggering Process method of closed generics

### DIFF
--- a/Source/StructureMap/Graph/PluginGraph.cs
+++ b/Source/StructureMap/Graph/PluginGraph.cs
@@ -116,7 +116,12 @@ namespace StructureMap.Graph
                 return;
             }
 
-            _scanners.ForEach(scanner => scanner.ScanForAll(this));
+            // This was changed to support .Net 4.5 which is stricture on collection modification	
+            int index = 0;
+            while (index < _scanners.Count())
+            {
+                _scanners[index++].ScanForAll(this);
+            }
 
             _pluginFamilies.Each(family => family.AddTypes(_pluggedTypes));
             _pluginFamilies.Each(family => family.Seal());


### PR DESCRIPTION
PluginGraph Seal method _scanner section was changed to a while loop since its collection is modified during iteration.  .Net 4.5 is stricture on this and therefor plugins are not being scanned.  Sorry about the additional commits in this pull, I accidentally committed a change that shouldn't have been there and then reverted it back and reset the new fix.
