### PR TITLE
Allow multiple instances of internal Registry-derived types

### DIFF
--- a/Source/StructureMap.Testing/Bugs/UseSingleImplementationConventionInMultipleScans.cs
+++ b/Source/StructureMap.Testing/Bugs/UseSingleImplementationConventionInMultipleScans.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using NUnit.Framework;
+using StructureMapBugRepo.NS1;
+using StructureMapBugRepo.NS2;
+
+namespace StructureMap.Testing.Bugs
+{
+    [TestFixture]
+    public class UseSingleImplementationConventionInMultipleScans
+    {
+        public void Repro()
+        {
+            var container = new Container(i =>
+            {
+                // Add our two registries. One is shared, the other is specific to this project.
+                // NOTE: Changing the order of these two will determine which GetInstance call fails.
+                i.AddRegistry<SharedRegistry>();
+                i.AddRegistry<MyRegistry>();
+            });
+
+            // One of these will, depending on the order of the two AddRegistry calls above.
+            container.TryGetInstance<IShared>().ShouldNotBeNull();
+            container.TryGetInstance<IMine>().ShouldNotBeNull();
+        }
+    }
+}
+
+namespace StructureMapBugRepo.NS1
+{
+    using StructureMap.Configuration.DSL;
+
+    public class SharedRegistry : Registry
+    {
+        public SharedRegistry()
+        {
+            Scan(s =>
+            {
+                // For this sample, we're using Namespaces, but in my real project, 
+                // it's two different assemblies, and has the exact same issue.
+                s.TheCallingAssembly();
+                s.IncludeNamespaceContainingType<IShared>();
+                s.SingleImplementationsOfInterface();
+            });
+        }
+    }
+
+    // Dummy class/interfaces just for sample.
+    public interface IShared { }
+    public class Shared : IShared { }
+}
+
+namespace StructureMapBugRepo.NS2
+{
+    using StructureMap.Configuration.DSL;
+
+    public class MyRegistry : Registry
+    {
+        public MyRegistry()
+        {
+            Scan(s =>
+            {
+                // For this sample, we're using Namespaces, but in my real project, 
+                // it's two different assemblies, and has the exact same issue.
+                s.TheCallingAssembly();
+                s.IncludeNamespaceContainingType<IMine>();
+                s.SingleImplementationsOfInterface();
+            });
+        }
+    }
+
+    // Dummy class/interfaces just for sample.
+    public interface IMine { }
+    public class Mine : IMine { }
+}

--- a/Source/StructureMap.Testing/Configuration/DSL/RegistryTester.cs
+++ b/Source/StructureMap.Testing/Configuration/DSL/RegistryTester.cs
@@ -81,7 +81,7 @@ namespace StructureMap.Testing.Configuration.DSL
         }
 
         [Test]
-        public void two_instances_of_a_derived_registry_type_are_considered_equal()
+        public void two_instances_of_a_public_derived_registry_type_are_considered_equal()
         {
             var registry1 = new TestRegistry();
             var registry2 = new TestRegistry();
@@ -95,6 +95,16 @@ namespace StructureMap.Testing.Configuration.DSL
 
             registry1.Equals((object)registry3).ShouldBeFalse();
             registry3.Equals((object)registry1).ShouldBeFalse();
+        }
+
+        [Test]
+        public void two_instances_of_a_non_public_derived_registry_type_are_not_considered_equal()
+        {
+            var registry1 = new InternalTestRegistry();
+            var registry2 = new InternalTestRegistry();
+
+            registry1.Equals((object) registry1).ShouldBeTrue();
+            registry1.Equals((object)registry2).ShouldBeFalse();
         }
 
         [Test]
@@ -201,6 +211,11 @@ namespace StructureMap.Testing.Configuration.DSL
 
         public int ExecutedCount { get { return _count; } }
     }
+
+    internal class InternalTestRegistry : Registry
+    {
+    }
+
 
     public class FakeGateway : IGateway
     {

--- a/Source/StructureMap.Testing/StructureMap.Testing.csproj
+++ b/Source/StructureMap.Testing/StructureMap.Testing.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Bugs\SpecifyScopeOnOpenGenericsTester.cs" />
     <Compile Include="Bugs\StaticPropertyCausesJITExceptionTester.cs" />
     <Compile Include="Bugs\TryGetInstanceWithOpenGenericsBugTester.cs" />
+    <Compile Include="Bugs\UseSingleImplementationConventionInMultipleScans.cs" />
     <Compile Include="BuildSessionTester.cs" />
     <Compile Include="BuildUpIntegratedTester.cs" />
     <Compile Include="BuildUpTester.cs" />

--- a/Source/StructureMap/Configuration/DSL/Registry.cs
+++ b/Source/StructureMap/Configuration/DSL/Registry.cs
@@ -422,7 +422,11 @@ namespace StructureMap.Configuration.DSL
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             if(other.GetType() == typeof(Registry) && GetType() == typeof(Registry)) return false;
-            return Equals(other.GetType(), GetType());
+            if (Equals(other.GetType(), GetType()))
+            {
+                return !GetType().IsNotPublic;
+            }
+            return false;
         }
 
         public override bool Equals(object obj)

--- a/Source/StructureMap/Graph/ImplementationMap.cs
+++ b/Source/StructureMap/Graph/ImplementationMap.cs
@@ -43,9 +43,14 @@ namespace StructureMap.Graph
         }
     }
 
-    internal class SingleImplementationRegistry : Registry
+    // This type created just to make the output clearer in WhatDoIHave()
+    // might consider adding a Description property to Registry instead
+    internal class SingleImplementationRegistry : Registry, IEquatable<SingleImplementationRegistry>
     {
-        // This type created just to make the output clearer in WhatDoIHave()
-        // might consider adding a Description property to Registry instead
+        public bool Equals(SingleImplementationRegistry other)
+        {
+            if (ReferenceEquals(this, other)) return true;
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Specifically targeted at SingleImplementationRegistry, which
should be allowed to be registered multiple times.

Closes gh-27
