### PR TITLE
Regression fix: find all types filter for open types

### DIFF
--- a/src/StructureMap.Testing/Graph/FindAllTypesFilterTester.cs
+++ b/src/StructureMap.Testing/Graph/FindAllTypesFilterTester.cs
@@ -12,7 +12,8 @@ namespace StructureMap.Testing.Graph
         public void it_registers_types_that_can_be_cast()
         {
             var registry = new Mock<Registry>(MockBehavior.Strict);
-            registry.Expect(x => x.AddType(It.IsAny<Type>(), typeof (Generic<>), It.IsAny<string>()))
+            registry
+				.Expect(x => x.AddType(It.IsAny<Type>(), typeof (Generic<>), It.IsAny<string>()))
                 .Callback<Type, Type, string>((x, y, z) =>
                                               Assert.That(x.GetGenericTypeDefinition(), Is.EqualTo(typeof (IGeneric<>))));
             var filter = new FindAllTypesFilter(typeof (IGeneric<>));
@@ -22,7 +23,7 @@ namespace StructureMap.Testing.Graph
         }
 
         [Test]
-        public void it_registers_types_implement_the_closed_generic_version()
+        public void it_registers_types_implementing_the_closed_generic_version()
         {
             var registry = new Mock<Registry>(MockBehavior.Strict);
             registry.Expect(x =>
@@ -32,8 +33,19 @@ namespace StructureMap.Testing.Graph
             filter.Process(typeof (StringGeneric), registry.Object);
             registry.VerifyAll();
         }
+		
+		[Test]
+		public void it_registers_open_types_which_can_be_cast()
+		{
+			var registry = new Mock<Registry>(MockBehavior.Strict);
+			registry.Expect(x => x.AddType(It.IsAny<Type>(), typeof(ConcreteGeneric<>), It.IsAny<string>()))
+				.Callback<Type, Type, string>((x, y, z) => Assert.That(x.GetGenericTypeDefinition(), Is.EqualTo(typeof (IGeneric<>))));
 
-        #region Nested type: Generic
+			var filter = new FindAllTypesFilter(typeof(IGeneric<>));
+
+			filter.Process(typeof(ConcreteGeneric<>), registry.Object);
+			registry.VerifyAll();
+		}
 
         public class Generic<T> : IGeneric<T>
         {
@@ -41,24 +53,13 @@ namespace StructureMap.Testing.Graph
             {
             }
         }
-
-        #endregion
-
-        #region Nested type: IGeneric
-
-        public interface IGeneric<T>
+		
+		public interface IGeneric<T>
         {
             void Nop();
         }
 
-        #endregion
-
-        #region Nested type: StringGeneric
-
-        public class StringGeneric : Generic<string>
-        {
-        }
-
-        #endregion
+        public class StringGeneric : Generic<string> { }
+		public class ConcreteGeneric<T> : Generic<T> { }
     }
 }

--- a/src/StructureMap/Graph/FindAllTypesFilter.cs
+++ b/src/StructureMap/Graph/FindAllTypesFilter.cs
@@ -26,7 +26,7 @@ namespace StructureMap.Graph
 
         private Type GetLeastSpecificButValidType(Type pluginType, Type type)
         {
-            if (pluginType.IsGenericTypeDefinition)
+            if (pluginType.IsGenericTypeDefinition && !type.IsOpenGeneric())
                 return type.FindFirstInterfaceThatCloses(pluginType);
 
             return pluginType;


### PR DESCRIPTION
When open types do not directly implement the desired pluginType they were not being added to the container. This worked previously in 2.6.3.
