### PR TITLE
Reduction of ObjectFactory footprint (related to #53)

### DIFF
--- a/src/StructureMap.Testing/Examples.cs
+++ b/src/StructureMap.Testing/Examples.cs
@@ -305,7 +305,7 @@ namespace StructureMap.Testing.DocumentationExamples
 
         private void editInvoice(Invoice invoice, ApplicationController controller)
         {
-            var presenter = ObjectFactory.With(invoice).GetInstance<EditInvoicePresenter>();
+            var presenter = ObjectFactory.Container.With(invoice).GetInstance<EditInvoicePresenter>();
             controller.ActivateScreen(presenter);
         }
     }
@@ -353,9 +353,9 @@ namespace StructureMap.Testing.DocumentationExamples
             // Put the main form, and some of its children into StructureMap
             // where other Controllers and Commands can get to them
             // without being coupled to the main form
-            ObjectFactory.Inject<IApplicationShell>(shell);
-            ObjectFactory.Inject(shell.QueryToolBar);
-            ObjectFactory.Inject(shell.ExplorerPane);
+            ObjectFactory.Container.Inject<IApplicationShell>(shell);
+            ObjectFactory.Container.Inject(shell.QueryToolBar);
+            ObjectFactory.Container.Inject(shell.ExplorerPane);
 
 
             Application.Run(shell);
@@ -378,7 +378,7 @@ namespace StructureMap.Testing.DocumentationExamples
         {
             if (_hasStarted)
             {
-                ObjectFactory.ResetDefaults();
+                ObjectFactory.Initialize(_=>{});
             }
             else
             {

--- a/src/StructureMap.Testing/Graph/TestExplicitArguments.cs
+++ b/src/StructureMap.Testing/Graph/TestExplicitArguments.cs
@@ -209,7 +209,7 @@ namespace StructureMap.Testing.Graph
             var theNode = new SpecialNode();
             var theTrade = new Trade();
 
-            var command = ObjectFactory
+            var command = ObjectFactory.Container
                 .With(typeof (Node), theNode)
                 .With(theTrade)
                 .GetInstance<Command>();
@@ -235,7 +235,7 @@ namespace StructureMap.Testing.Graph
 
             // Now, set the explicit arg for IProvider
             var theBlueProvider = new BlueProvider();
-            var secondTarget = ObjectFactory.With<IProvider>(theBlueProvider).GetInstance<ExplicitTarget>();
+            var secondTarget = ObjectFactory.Container.With<IProvider>(theBlueProvider).GetInstance<ExplicitTarget>();
             Assert.AreSame(theBlueProvider, secondTarget.Provider);
         }
 
@@ -254,7 +254,7 @@ namespace StructureMap.Testing.Graph
 
             // Now, set the explicit arg for IProvider
             var theBlueProvider = new BlueProvider();
-            ObjectFactory.With<IProvider>(theBlueProvider).GetInstance<ExplicitTarget>()
+            ObjectFactory.Container.With<IProvider>(theBlueProvider).GetInstance<ExplicitTarget>()
                 .Provider.ShouldBeTheSameAs(theBlueProvider);
         }
 
@@ -273,7 +273,7 @@ namespace StructureMap.Testing.Graph
             Assert.AreEqual("Jeremy", firstTarget.Name);
 
             // Now, set the explicit arg for IProvider
-            var secondTarget = ObjectFactory.With("name").EqualTo("Julia").GetInstance<ExplicitTarget>();
+            var secondTarget = ObjectFactory.Container.With("name").EqualTo("Julia").GetInstance<ExplicitTarget>();
             Assert.AreEqual("Julia", secondTarget.Name);
         }
 
@@ -358,7 +358,7 @@ namespace StructureMap.Testing.Graph
 
             var theLump = new Lump();
 
-            var provider = (LumpProvider) ObjectFactory.With(theLump).GetInstance<IProvider>();
+            var provider = (LumpProvider)ObjectFactory.Container.With(theLump).GetInstance<IProvider>();
             Assert.AreSame(theLump, provider.Lump);
         }
 
@@ -366,7 +366,7 @@ namespace StructureMap.Testing.Graph
         public void PassAnArgumentIntoExplicitArgumentsThatMightNotAlreadyBeRegistered()
         {
             var theLump = new Lump();
-            var provider = ObjectFactory.With(theLump).GetInstance<LumpProvider>();
+            var provider = ObjectFactory.Container.With(theLump).GetInstance<LumpProvider>();
             Assert.AreSame(theLump, provider.Lump);
         }
 

--- a/src/StructureMap.Testing/ObjectFactoryInitializeTester.cs
+++ b/src/StructureMap.Testing/ObjectFactoryInitializeTester.cs
@@ -54,23 +54,6 @@ namespace StructureMap.Testing
             ObjectFactory.Initialize(x => { });
         }
 
-
-        [Test]
-        public void TheDefaultNameIs_should_set_the_default_profile_name()
-        {
-            string theDefaultProfileName = "the default profile";
-
-            ObjectFactory.Initialize(x =>
-            {
-                x.Profile(theDefaultProfileName, p => {
-                    p.For<IGateway>().Use(() => null);
-                });
-
-                x.DefaultProfileName = theDefaultProfileName;
-            });
-
-            ObjectFactory.Profile.ShouldEqual(theDefaultProfileName);
-        }
         
         [Test]
         public void TheDefaultContainerName_should_be_ObjectFactory_Guid()

--- a/src/StructureMap.Testing/Pipeline/GenericsHelperExpressionTester.cs
+++ b/src/StructureMap.Testing/Pipeline/GenericsHelperExpressionTester.cs
@@ -178,7 +178,7 @@ namespace StructureMap.Testing.Pipeline
                 x => { x.For<IHandler<Shipment>>().Use<ShipmentHandler>(); });
 
             var shipment = new Shipment();
-            var handler = ObjectFactory.ForObject(shipment).GetClosedTypeOf(typeof (IHandler<>)).As<IHandler>();
+            var handler = ObjectFactory.Container.ForObject(shipment).GetClosedTypeOf(typeof (IHandler<>)).As<IHandler>();
 
             handler.ShouldBeOfType<ShipmentHandler>().Shipment.ShouldBeTheSameAs(shipment);
         }

--- a/src/StructureMap/Container.cs
+++ b/src/StructureMap/Container.cs
@@ -64,7 +64,7 @@ namespace StructureMap
         /// <summary>
         /// Provides queryable access to the configured PluginType's and Instances of this Container
         /// </summary>
-        public IModel Model { get { return new Model(_pipelineGraph, this); } }
+        public IModel Model { get { return new Model(_pipelineGraph, _pluginGraph, this); } }
 
         /// <summary>
         /// Creates or finds the named instance of T
@@ -309,7 +309,7 @@ namespace StructureMap
         /// <summary>
         /// Returns a report detailing the complete configuration of all PluginTypes and Instances
         /// </summary>
-        /// <returns></returns>
+
         public string WhatDoIHave()
         {
             var writer = new WhatDoIHaveWriter(_pipelineGraph);
@@ -493,8 +493,6 @@ namespace StructureMap
         /// pluginType.  Mostly used for temporarily setting up return values of the Container
         /// to introduce mocks or stubs during automated testing scenarios
         /// </summary>
-        /// <param name="pluginType"></param>
-        /// <param name="object"></param>
         public void Inject(Type pluginType, object @object)
         {
             Configure(x => x.For(pluginType).Use(@object));

--- a/src/StructureMap/Diagnostics/DoctorRunner.cs
+++ b/src/StructureMap/Diagnostics/DoctorRunner.cs
@@ -40,7 +40,7 @@ namespace StructureMap.Diagnostics
             {
                 bootstrapper.BootstrapStructureMap();
 
-                PluginGraph graph = ObjectFactory.PluginGraph;
+                var graph = (PluginGraph)ObjectFactory.Container.Model.PluginGraph;
 
                 if (graph.Log.ErrorCount > 0)
                 {

--- a/src/StructureMap/Diagnostics/GraphLog.cs
+++ b/src/StructureMap/Diagnostics/GraphLog.cs
@@ -70,6 +70,8 @@ namespace StructureMap.Diagnostics
 
         public string BuildFailureMessage()
         {
+            if (_errors.Count == 0)
+                return "No Errors";
             var sb = new StringBuilder();
             var writer = new StringWriter(sb);
 

--- a/src/StructureMap/InitializationExpression.cs
+++ b/src/StructureMap/InitializationExpression.cs
@@ -9,12 +9,7 @@ namespace StructureMap
 {
     public interface IInitializationExpression : IRegistry
     {
-        /// <summary>
-        /// Designate the Default Profile.  This will be applied as soon as the 
-        /// Container is initialized.
-        /// </summary>
-        string DefaultProfileName { get; set; }
-
+        
         /// <summary>
         /// Imports configuration from an Xml file.  The fileName
         /// must point to an Xml file with valid StructureMap

--- a/src/StructureMap/ObjectFactory.cs
+++ b/src/StructureMap/ObjectFactory.cs
@@ -1,416 +1,121 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using StructureMap.Graph;
+using System.Threading;
 using StructureMap.Pipeline;
-using StructureMap.Query;
 
 namespace StructureMap
 {
-    public delegate void Notify();
-
     /// <summary>
-    /// The main static Facade for the StructureMap container
+    /// A convenience "Containment" to hold your container if you are planning to have a single static <see cref="IContainer"/> instance in your application.
+    /// 
     /// </summary>
-    //[EnvironmentPermission(SecurityAction.Assert, Read = "COMPUTERNAME")]
     public static class ObjectFactory
     {
         private static readonly object _lockObject = new object();
-        private static Container _container;
-        private static string _profile = string.Empty;
+        private static Lazy<Container> _containerBuilder = new Lazy<Container>(defaultContainer,LazyThreadSafetyMode.ExecutionAndPublication);
 
         /// <summary>
-        /// Provides queryable access to the configured PluginType's and Instances of the inner Container
+        /// The Container that is kept alive by the ObjectFactory
         /// </summary>
-        public static IModel Model { get { return container.Model; } }
+        public static IContainer Container { get { return _containerBuilder.Value; } }
 
-        public static IContainer Container { get { return container; } }
-
-        private static event Notify _notify;
-
-        /// <summary>
-        /// Restarts ObjectFactory and blows away all Singleton's and cached instances.  Use with caution.
-        /// </summary>
-        internal static void Reset()
+        private static Container defaultContainer()
         {
+            var c = new Container();
+            nameContainer(c);
+            return c;
+        }
+
+        /// <summary>
+        /// Fire up and initialize a new container. It is accessible through the <see cref="Container"/> property.
+        /// Some convenience methods are available that route to this container. Passing no action equates to starting the container
+        /// without any configuration. A subsequent call to this method will overwrite the reference that the Objectfactory held to the previous
+        /// <see cref="IContainer"/> instance.
+        /// </summary>
+        public static void Initialize(Action<IInitializationExpression> action = null)
+        {
+            if (action == null)
+                return;
             lock (_lockObject)
-            {
-                _container = null;
-                _profile = string.Empty;
-
-                if (_notify != null)
-                {
-                    _notify();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Remove and dispose all objects scoped by HttpContext.  Call this method at the *end* of an Http request to clean up resources
-        /// </summary>
-        public static void ReleaseAndDisposeAllHttpScopedObjects()
-        {
-            HttpContextLifecycle.DisposeAndClearAll();
-        }
-
-        public static void Initialize(Action<IInitializationExpression> action)
-        {
-            lock (typeof (ObjectFactory))
             {
                 var expression = new InitializationExpression();
                 action(expression);
 
-                PluginGraph graph = expression.BuildGraph();
-
-                _container = new Container(graph);
-                nameContainer(_container);
-                Profile = expression.DefaultProfileName;
+                var graph = expression.BuildGraph();
+                var container = new Container(graph);
+                _containerBuilder = new Lazy<Container>(()=>container);
+                nameContainer(container);
             }
         }
 
-
         /// <summary>
-        /// Injects the given object into a Container as the default for the designated
-        /// pluginType.  Mostly used for temporarily setting up return values of the Container
-        /// to introduce mocks or stubs during automated testing scenarios
+        /// Used to add additional configuration to a Container *after* the initialization.
         /// </summary>
-        /// <param name="pluginType"></param>
-        /// <param name="instance"></param>
-        public static void Inject(Type pluginType, object instance)
+        public static void Configure(Action<ConfigurationExpression> configure)
         {
-            container.Inject(pluginType, instance);
-        }
-
-        /// <summary>
-        /// Injects the given object into a Container as the default for the designated
-        /// TPluginType.  Mostly used for temporarily setting up return values of the Container
-        /// to introduce mocks or stubs during automated testing scenarios
-        /// </summary>
-        /// <typeparam name="TPluginType"></typeparam>
-        /// <param name="instance"></param>
-        public static void Inject<TPluginType>(TPluginType instance)
-        {
-            container.Inject(instance);
-        }
-
-
-        /// <summary>
-        /// Returns a report detailing the complete configuration of all PluginTypes and Instances
-        /// </summary>
-        /// <returns></returns>
-        public static string WhatDoIHave()
-        {
-            return container.WhatDoIHave();
-        }
-
-        /// <summary>
-        /// Use with caution!  Does a full environment test of the configuration of this container.  Will try to create every configured
-        /// instance and afterward calls any methods marked with the [ValidationMethod] attribute
-        /// </summary>
-        public static void AssertConfigurationIsValid()
-        {
-            container.AssertConfigurationIsValid();
+            Container.Configure(configure);
         }
 
         /// <summary>
         /// Creates or finds the default instance of the pluginType
         /// </summary>
-        /// <param name="pluginType"></param>
-        /// <returns></returns>
         public static object GetInstance(Type pluginType)
         {
-            return container.GetInstance(pluginType);
+            return Container.GetInstance(pluginType);
         }
 
         /// <summary>
         /// Creates or finds the default instance of type T
         /// </summary>
-        /// <typeparam name="TPluginType"></typeparam>
-        /// <returns></returns>
         public static TPluginType GetInstance<TPluginType>()
         {
-            return container.GetInstance<TPluginType>();
-        }
-
-        /// <summary>
-        /// Creates a new instance of the requested type using the supplied Instance.  Mostly used internally
-        /// </summary>
-        /// <param name="targetType"></param>
-        /// <param name="instance"></param>
-        /// <returns></returns>
-        public static object GetInstance(Type targetType, Instance instance)
-        {
-            return container.GetInstance(targetType, instance);
-        }
-
-        /// <summary>
-        /// Creates a new instance of the requested type T using the supplied Instance.  Mostly used internally
-        /// </summary>
-        /// <param name="instance"></param>
-        /// <returns></returns>
-        public static T GetInstance<T>(Instance instance)
-        {
-            return container.GetInstance<T>(instance);
+            return Container.GetInstance<TPluginType>();
         }
 
         /// <summary>
         /// Creates or finds the named instance of the pluginType
         /// </summary>
-        /// <param name="pluginType"></param>
-        /// <param name="name"></param>
-        /// <returns></returns>
         public static object GetNamedInstance(Type pluginType, string name)
         {
-            return container.GetInstance(pluginType, name);
+            return Container.GetInstance(pluginType, name);
         }
 
         /// <summary>
         /// Creates or finds the named instance of T
         /// </summary>
-        /// <typeparam name="TPluginType"></typeparam>
-        /// <param name="name"></param>
-        /// <returns></returns>
         public static TPluginType GetNamedInstance<TPluginType>(string name)
         {
-            return container.GetInstance<TPluginType>(name);
+            return Container.GetInstance<TPluginType>(name);
         }
 
 
         /// <summary>
         /// Creates or resolves all registered instances of the pluginType
         /// </summary>
-        /// <param name="pluginType"></param>
-        /// <returns></returns>
         public static IList GetAllInstances(Type pluginType)
         {
-            return container.GetAllInstances(pluginType);
+            return Container.GetAllInstances(pluginType);
         }
 
         /// <summary>
         /// Creates or resolves all registered instances of type T
         /// </summary>
-        /// <typeparam name="TPluginType"></typeparam>
-        /// <returns></returns>
         public static IList<TPluginType> GetAllInstances<TPluginType>()
         {
-            return container.GetAllInstances<TPluginType>();
+            return Container.GetAllInstances<TPluginType>();
         }
 
-        /// <summary>
-        /// Starts a request for an instance or instances with explicitly configured arguments.  Specifies that any dependency
-        /// of type T should be "arg"
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="arg"></param>
-        /// <returns></returns>
-        public static ExplicitArgsExpression With<T>(T arg)
-        {
-            return container.With(arg);
-        }
-
-        /// <summary>
-        /// Starts a request for an instance or instances with explicitly configured arguments.  Specifies that any dependency or primitive argument
-        /// with the designated name should be the next value.
-        /// </summary>
-        /// <param name="argName"></param>
-        /// <returns></returns>
-        public static IExplicitProperty With(string argName)
-        {
-            return container.With(argName);
-        }
-
-        /// <summary>
-        /// Starts a request for an instance or instances with explicitly configured arguments.  Specifies that any dependency
-        /// of type T should be "arg"
-        /// </summary>
-        /// <param name="pluginType"></param>
-        /// <param name="arg"></param>
-        /// <returns></returns>
-        public static ExplicitArgsExpression With(Type pluginType, object arg)
-        {
-            return container.With(pluginType, arg);
-        }
-
-        /// <summary>
-        /// Removes all configured instances of type T from the Container.  Use with caution!
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        public static void EjectAllInstancesOf<T>()
-        {
-            container.EjectAllInstancesOf<T>();
-        }
-
-        public static T GetInstance<T>(ExplicitArguments args)
-        {
-            return container.GetInstance<T>(args);
-        }
-
-        /// <summary>
-        /// Creates or finds the named instance of the pluginType. Returns null if the named instance is not known to the container.
-        /// </summary>
-        /// <param name="pluginType"></param>
-        /// <param name="instanceKey"></param>
-        /// <returns></returns>
-        public static object TryGetInstance(Type pluginType, string instanceKey)
-        {
-            return container.TryGetInstance(pluginType, instanceKey);
-        }
-
-        /// <summary>
-        /// Creates or finds the default instance of the pluginType. Returns null if the pluginType is not known to the container.
-        /// </summary>
-        /// <param name="pluginType"></param>
-        /// <returns></returns>
-        public static object TryGetInstance(Type pluginType)
-        {
-            return container.TryGetInstance(pluginType);
-        }
-
-        /// <summary>
-        /// Creates or finds the default instance of type T. Returns the default value of T if it is not known to the container.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public static T TryGetInstance<T>()
-        {
-            return container.TryGetInstance<T>();
-        }
-
-        /// <summary>
-        /// Creates or finds the named instance of type T. Returns the default value of T if the named instance is not known to the container.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="instanceKey"></param>
-        /// <returns></returns>
-        public static T TryGetInstance<T>(string instanceKey)
-        {
-            return container.TryGetInstance<T>(instanceKey);
-        }
 
         /// <summary>
         /// The "BuildUp" method takes in an already constructed object
         /// and uses Setter Injection to push in configured dependencies
-        /// of that object
+        /// of that object.
         /// </summary>
-        /// <param name="target"></param>
         public static void BuildUp(object target)
         {
-            container.BuildUp(target);
+            Container.BuildUp(target);
         }
-
-        /// <summary>
-        /// Convenience method to request an object using an Open Generic
-        /// Type and its parameter Types
-        /// </summary>
-        /// <param name="templateType"></param>
-        /// <returns></returns>
-        /// <example>
-        /// IFlattener flattener1 = container.ForGenericType(typeof (IFlattener&lt;&gt;))
-        ///     .WithParameters(typeof (Address)).GetInstanceAs&lt;IFlattener&gt;();
-        /// </example>
-        public static Container.OpenGenericTypeExpression ForGenericType(Type templateType)
-        {
-            return container.ForGenericType(templateType);
-        }
-
-
-        /// <summary>
-        /// Shortcut syntax for using an object to find a service that handles
-        /// that type of object by using an open generic type
-        /// </summary>
-        /// <example>
-        /// IHandler handler = container.ForObject(shipment)
-        ///                        .GetClosedTypeOf(typeof (IHandler<>))
-        ///                        .As<IHandler>();
-        /// </example>
-        /// <param name="subject"></param>
-        /// <returns></returns>
-        public static CloseGenericTypeExpression ForObject(object subject)
-        {
-            return container.ForObject(subject);
-        }
-
-        #region Container and setting defaults
-
-        private static Container container
-        {
-            get
-            {
-                if (_container == null)
-                {
-                    lock (_lockObject)
-                    {
-                        if (_container == null)
-                        {
-                            _container = new Container();
-                            nameContainer(_container);
-                        }
-                    }
-                }
-
-                return _container;
-            }
-        }
-
-        /// <summary>
-        /// Sets the default instance for all PluginType's to the designated Profile.
-        /// </summary>
-        public static string Profile
-        {
-            set
-            {
-                lock (_lockObject)
-                {
-                    _profile = value;
-                    container.SetDefaultsToProfile(_profile);
-                }
-            }
-            get { return _profile; }
-        }
-
-        internal static PluginGraph PluginGraph { get { return container.PluginGraph; } }
-
-
-        internal static void ReplaceManager(Container container)
-        {
-            _container = container;
-        }
-
-        /// <summary>
-        /// Used to add additional configuration to a Container *after* the initialization.
-        /// </summary>
-        /// <param name="configure"></param>
-        public static void Configure(Action<ConfigurationExpression> configure)
-        {
-            container.Configure(configure);
-        }
-
-        public static event Notify Refresh { add { _notify += value; } remove { _notify -= value; } }
-
-
-        public static void ResetDefaults()
-        {
-            try
-            {
-                lock (_lockObject)
-                {
-                    Profile = string.Empty;
-                }
-            }
-            catch (TypeInitializationException ex)
-            {
-                if (ex.InnerException is StructureMapException)
-                {
-                    throw ex.InnerException;
-                }
-                else
-                {
-                    throw;
-                }
-            }
-        }
-
-        #endregion
 
         private static void nameContainer(IContainer container)
         {

--- a/src/StructureMap/Pipeline/HttpContextLifecycle.cs
+++ b/src/StructureMap/Pipeline/HttpContextLifecycle.cs
@@ -42,6 +42,9 @@ namespace StructureMap.Pipeline
             return HttpContext.Current != null;
         }
 
+        /// <summary>
+        /// Remove and dispose all objects scoped by HttpContext.  Call this method at the *end* of an Http request to clean up resources
+        /// </summary>
         public static void DisposeAndClearAll()
         {
             new HttpContextLifecycle().FindCache().DisposeAndClear();

--- a/src/StructureMap/Query/IModel.cs
+++ b/src/StructureMap/Query/IModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using StructureMap.Graph;
 
 namespace StructureMap.Query
 {
@@ -13,6 +14,11 @@ namespace StructureMap.Query
         /// Access to all the <seealso cref="IPluginTypeConfiguration">Plugin Type</seealso> registrations 
         /// </summary>
         IEnumerable<IPluginTypeConfiguration> PluginTypes { get; }
+
+        /// <summary>
+        /// Access to the plugin graph
+        /// </summary>
+        IPluginGraph PluginGraph { get; }
 
         IEnumerable<InstanceRef> AllInstances { get; }
 

--- a/src/StructureMap/Query/Model.cs
+++ b/src/StructureMap/Query/Model.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using StructureMap.Graph;
 using StructureMap.TypeRules;
 
 namespace StructureMap.Query
@@ -10,10 +11,11 @@ namespace StructureMap.Query
         private readonly IContainer _container;
         private readonly PipelineGraph _graph;
 
-        internal Model(PipelineGraph graph, IContainer container)
+        internal Model(PipelineGraph graph, PluginGraph pluginGraph, IContainer container)
         {
             _graph = graph;
             _container = container;
+            PluginGraph = pluginGraph;
         }
 
         #region IModel Members
@@ -41,6 +43,8 @@ namespace StructureMap.Query
         }
 
         public IEnumerable<IPluginTypeConfiguration> PluginTypes { get { return pluginTypes; } }
+        
+        public IPluginGraph PluginGraph { get; private set; }
 
         /// <summary>
         /// Retrieves the configuration for the given type


### PR DESCRIPTION
- Kept Container and basic GetInstance methods for convenience
- Rewritten tests to access ObjFac.Container
- Removed DefaultProfile from IInitializationExpression and a related test
  because nobody seemed to use the getter internally and the property is
  defined on an interface that the user doesn't touch a lot.
- Slight ugliness in DoctorRunner making a cast to PluginGraph, but since all the Diagnostic thing gets an overhaul I suppose one can live with that for now.
