### PR TITLE
Replacement of getexecutingassembly

### DIFF
--- a/src/StructureMap/Building/TryCatchWrapper.cs
+++ b/src/StructureMap/Building/TryCatchWrapper.cs
@@ -14,7 +14,9 @@ namespace StructureMap.Building
 
         static TryCatchWrapper()
         {
-            Assembly.GetExecutingAssembly().GetExportedTypes().Where(x => x.CanBeCastTo<StructureMapException>())
+            typeof(StructureMapException).GetTypeInfo()
+                .Assembly.GetExportedTypes()
+                .Where(x => x.CanBeCastTo<StructureMapException>())
                 .Each(type => _constructors.FillDefault(type));
         }
 


### PR DESCRIPTION
In Windows Store getexecutingassembly is not exposed, since it is not
guranteed to give proper answers e.g. in method inlining - hence deriving
assembly from a well-known type.

At this point all code compiles in both targetted profiles. If I understand the docs correctly at http://docs.nuget.org/docs/release-notes/nuget-2.1, the following directory names should apply for the compiled dlls
- Debug  -> portable-win+net40
- NET45WP8 -> portable-windows8+net45+wp8 
