### PR TITLE
GetAllInstances : When mixed open closed generic types are present only closed types are resolved

### DIFF
--- a/src/StructureMap.Testing/Resolving_mixed_open_and_closed_generic_types.cs
+++ b/src/StructureMap.Testing/Resolving_mixed_open_and_closed_generic_types.cs
@@ -1,10 +1,10 @@
 using System.Linq;
 using NUnit.Framework;
 
-namespace StructureMap.Testing.Bugs
+namespace StructureMap.Testing
 {
 	[TestFixture]
-	public class resolve_all_open_and_closed_generic_types
+	public class Resolving_mixed_open_and_closed_generic_types
 	{
 		[Test]
 		public void when_only_open_instances_are_present_they_are_resolved()
@@ -17,9 +17,9 @@ namespace StructureMap.Testing.Bugs
 
 			var instances = container.GetAllInstances<INeedAnEntity<Entity>>().ToArray();
 
+			instances.Length.ShouldEqual(2);
 			instances[0].GetType().Name.ShouldEqual("OpenEntityType`1");
 			instances[1].GetType().Name.ShouldEqual("AnotherOpenEntityType`1");
-			instances.Length.ShouldEqual(2);
 		}
 
 		[Test]
@@ -34,17 +34,13 @@ namespace StructureMap.Testing.Bugs
 
 			var instances = container.GetAllInstances<INeedAnEntity<Entity>>().ToArray();
 
+			instances.Length.ShouldEqual(2);
 			instances[0].GetType().Name.ShouldEqual("ClosedEntityType");
 			instances[1].GetType().Name.ShouldEqual("AnotherClosedEntityType");
-
-			//Fails here with only the closed types being resolved
-			instances.Length.ShouldEqual(3);
-			instances[2].GetType().Name.ShouldEqual("OpenEntityType`1");
 		}
 	}
 
-
-	public class Entity {}
+	public class Entity { }
 
 	public interface INeedAnEntity<T>
 	{
@@ -65,4 +61,5 @@ namespace StructureMap.Testing.Bugs
 	public class AnotherOpenEntityType<T> : INeedAnEntity<T>
 	{
 	}
+
 }

--- a/src/StructureMap.Testing/StructureMap.Testing.csproj
+++ b/src/StructureMap.Testing/StructureMap.Testing.csproj
@@ -180,7 +180,6 @@
     <Compile Include="AutoWiringExamples.cs" />
     <Compile Include="BidirectionalDependencies.cs" />
     <Compile Include="Bugs\AddValueDirectlyWithGenericUsage.cs" />
-    <Compile Include="Bugs\resolve_all_open_and_closed_generic_types.cs" />
     <Compile Include="Bugs\Bug_101.cs" />
     <Compile Include="Bugs\BuildUpBug.cs" />
     <Compile Include="Bugs\CloseOpenGenericsWithSomeSpecifics.cs" />
@@ -347,6 +346,7 @@
     <Compile Include="Query\ModelIntegrationTester.cs" />
     <Compile Include="ReflectionHelper.cs" />
     <Compile Include="RegistryExtensions.cs" />
+    <Compile Include="Resolving_mixed_open_and_closed_generic_types.cs" />
     <Compile Include="SessionCacheTester.cs" />
     <Compile Include="SpecificationExtensions.cs" />
     <Compile Include="StructureMapConfigurationTester.cs" />


### PR DESCRIPTION
Sharing these passing tests in hopes that they document the current GetAllInstances behavior for mixed open and closed generic types. Currently in 2.6 and 3.0 when both open and closed types are registered in the Container for the requested generic type only close instances are resolved. 

I am working around this currently by only registering open types into the container. I constrain the open type that is really for a single concrete type by using generic constraints. 

``` cs
public class OpenButConstrained<T> : INeedAnEntity<T> where T : Entity {}
```

Jeremy and I discussed on Twitter that having mixed and open and closed types returned would diverge from existing behavior. He suggested that a policy be created to add this behavior to StructureMap 3 in the future. 
