### PR TITLE
Registry Classes, Including, Named Instances Docs

### DIFF
--- a/src/StructureMap.Docs/6.registration/1.registry-dsl.spark
+++ b/src/StructureMap.Docs/6.registration/1.registry-dsl.spark
@@ -2,6 +2,48 @@
 <!--Url: registry-dsl-->
 
 <markdown>
-TODO(Write some content!)
+
+Creating `Registry` classes is the recommended way of using the Registry DSL. 
+
+The Registry DSL is mostly a [fluent interface][1] with some nested [closure][2] 
+usage. The intent of the Registry DSL is to make the configuration process as 
+error free as possible by using "compiler safe" expressions and defensive 
+programming to point out missing data.
+
+<Section title="The Registry Class" id="registry-class">
+
+On all but the smallest systems, the main unit of configuration will probably be 
+the `Registry` class.  Typically, you would subclass the `Registry` class, then 
+use the Fluent Interface methods exposed by the Registry class to create Container 
+configuration. Here's a sample `Registry` class below used to configure an 
+instance of an `IWidget` interface:
+
+<Snippet name="simple-registry" />
+</Section>
+
+<Section title="Including Registries" id="including-registries">
+
+The next question is "how does my new `Registry` class get used?" 
+
+When you set up a `Container` or `ObjectFactory`, you need to simply direct the 
+`Container` to use the configuration in that `Registry` class:
+
+<Snippet name="including-registries" />
+</Section>
+
+<Section title="Named Instances" id="named-instances">
+
+When you have multiple implementations of an interface, it can often be useful to
+name instances. To retrieve a specific implementation:
+
+<Snippet name="named-instance" />
+
+You can also register named instances with the following shorthand:
+
+<Snippet name="named-instances-shorthand" />
+</Section>
+
+[1]: http://martinfowler.com/bliki/FluentInterface.html
+[2]: http://en.wikipedia.org/wiki/Closure_%28computer_programming%29
 </markdown>
 

--- a/src/StructureMap.Docs/snippets/StructureMap.Testing/Configuration/DSL/AddInstanceTester.cs
+++ b/src/StructureMap.Docs/snippets/StructureMap.Testing/Configuration/DSL/AddInstanceTester.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Configuration;
+using NUnit.Framework;
+using StructureMap.Pipeline;
+using StructureMap.Testing.Widget;
+
+namespace StructureMap.Testing.Configuration.DSL
+{
+    [TestFixture]
+    public class AddInstanceTester
+    {
+        #region Setup/Teardown
+
+        [SetUp]
+        public void SetUp()
+        {
+            container = new Container(registry => {
+                registry.Scan(x => x.AssemblyContainingType<ColorWidget>());
+
+                // Add an instance with properties
+                registry.For<IWidget>()
+                    .Add<ColorWidget>()
+                    .Named("DarkGreen")
+                    .Ctor<string>("color").Is("DarkGreen");
+
+                // Add an instance by specifying the ConcreteKey
+                registry.For<IWidget>()
+                    .Add<ColorWidget>()
+                    .Named("Purple")
+                    .Ctor<string>("color").Is("Purple");
+
+                registry.For<IWidget>().Add<AWidget>();
+            });
+        }
+
+        #endregion
+
+        private IContainer container;
+
+        [Test]
+        public void AddAnInstanceWithANameAndAPropertySpecifyingConcreteKey()
+        {
+            var widget = (ColorWidget) container.GetInstance<IWidget>("Purple");
+            Assert.AreEqual("Purple", widget.Color);
+        }
+
+        [Test]
+        public void AddAnInstanceWithANameAndAPropertySpecifyingConcreteType()
+        {
+            var widget = (ColorWidget) container.GetInstance<IWidget>("DarkGreen");
+            Assert.AreEqual("DarkGreen", widget.Color);
+        }
+
+        [Test]
+        public void AddInstanceAndOverrideTheConcreteTypeForADependency()
+        {
+            IContainer container = new Container(x => {
+                x.For<Rule>().Add<WidgetRule>()
+                    .Named("AWidgetRule")
+                    .Ctor<IWidget>().IsSpecial(i => i.Type<AWidget>());
+            });
+
+            container.GetInstance<Rule>("AWidgetRule")
+                .IsType<WidgetRule>()
+                .Widget.IsType<AWidget>();
+        }
+
+        // SAMPLE: named-instance
+        [Test]
+        public void SimpleCaseWithNamedInstance()
+        {
+            container = new Container(x => { x.For<IWidget>().Add<AWidget>().Named("MyInstance"); });
+            // retrieve an instance by name
+            var widget = (AWidget) container.GetInstance<IWidget>("MyInstance");
+            Assert.IsNotNull(widget);
+        }
+        // ENDSAMPLE
+
+        [Test]
+        public void SpecifyANewInstanceOverrideADependencyWithANamedInstance()
+        {
+            container = new Container(registry => {
+                registry.For<Rule>().Add<ARule>().Named("Alias");
+
+                // Add an instance by specifying the ConcreteKey
+                registry.For<IWidget>()
+                    .Add<ColorWidget>()
+                    .Named("Purple")
+                    .Ctor<string>("color").Is("Purple");
+
+                // Specify a new Instance, override a dependency with a named instance
+                registry.For<Rule>().Add<WidgetRule>().Named("RuleThatUsesMyInstance")
+                    .Ctor<IWidget>("widget").IsSpecial(x => x.TheInstanceNamed("Purple"));
+            });
+
+            container.GetInstance<Rule>("Alias").ShouldBeOfType<ARule>();
+
+            var rule = (WidgetRule) container.GetInstance<Rule>("RuleThatUsesMyInstance");
+            var widget = (ColorWidget) rule.Widget;
+            Assert.AreEqual("Purple", widget.Color);
+        }
+
+        [Test]
+        public void SpecifyANewInstanceWithADependency()
+        {
+            // Specify a new Instance, create an instance for a dependency on the fly
+            var instanceKey = "OrangeWidgetRule";
+
+            var theContainer = new Container(registry => {
+                registry.For<Rule>().Add<WidgetRule>().Named(instanceKey)
+                    .Ctor<IWidget>().IsSpecial(
+                        i => { i.Type<ColorWidget>().Ctor<string>("color").Is("Orange").Named("Orange"); });
+            });
+
+            var rule = (WidgetRule) theContainer.GetInstance<Rule>(instanceKey);
+            var widget = (ColorWidget) rule.Widget;
+            Assert.AreEqual("Orange", widget.Color);
+        }
+
+
+        [Test]
+        public void UseAPreBuiltObjectWithAName()
+        {
+            // Return the specific instance when an IWidget named "Julia" is requested
+            var julia = new CloneableWidget("Julia");
+
+            container =
+                new Container(x => x.For<IWidget>().Add(julia).Named("Julia"));
+
+            var widget1 = (CloneableWidget) container.GetInstance<IWidget>("Julia");
+            var widget2 = (CloneableWidget) container.GetInstance<IWidget>("Julia");
+            var widget3 = (CloneableWidget) container.GetInstance<IWidget>("Julia");
+
+            Assert.AreSame(julia, widget1);
+            Assert.AreSame(julia, widget2);
+            Assert.AreSame(julia, widget3);
+        }
+    }
+
+
+    public class WidgetRule : Rule
+    {
+        private readonly IWidget _widget;
+
+        public WidgetRule(IWidget widget)
+        {
+            _widget = widget;
+        }
+
+
+        public IWidget Widget
+        {
+            get { return _widget; }
+        }
+
+
+        public override bool Equals(object obj)
+        {
+            if (this == obj) return true;
+            var widgetRule = obj as WidgetRule;
+            if (widgetRule == null) return false;
+            return Equals(_widget, widgetRule._widget);
+        }
+
+        public override int GetHashCode()
+        {
+            return _widget != null ? _widget.GetHashCode() : 0;
+        }
+    }
+
+    public class WidgetThing : IWidget
+    {
+        #region IWidget Members
+
+        public void DoSomething()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+
+    [Serializable]
+    public class CloneableWidget : IWidget, ICloneable
+    {
+        private readonly string _name;
+
+
+        public CloneableWidget(string name)
+        {
+            _name = name;
+        }
+
+        public string Name
+        {
+            get { return _name; }
+        }
+
+        #region ICloneable Members
+
+        public object Clone()
+        {
+            return MemberwiseClone();
+        }
+
+        #endregion
+
+        #region IWidget Members
+
+        public void DoSomething()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+
+    public class ARule : Rule
+    {
+    }
+}

--- a/src/StructureMap.Docs/snippets/StructureMap.Testing/Configuration/DSL/AddTypesTester.cs
+++ b/src/StructureMap.Docs/snippets/StructureMap.Testing/Configuration/DSL/AddTypesTester.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using NUnit.Framework;
+
+namespace StructureMap.Testing.Configuration.DSL
+{
+    [TestFixture]
+    public class AddTypesTester
+    {
+        public interface IAddTypes
+        {
+        }
+
+        public class RedAddTypes : IAddTypes
+        {
+        }
+
+        public class GreenAddTypes : IAddTypes
+        {
+        }
+
+        public class BlueAddTypes : IAddTypes
+        {
+        }
+
+        public class PurpleAddTypes : IAddTypes
+        {
+        }
+
+        // SAMPLE: named-instances-shorthand
+        [Test]
+        public void A_concrete_type_is_available_by_name_when_it_is_added_by_the_shorthand_mechanism()
+        {
+            IContainer container = new Container(r => r.For<IAddTypes>().AddInstances(x => {
+                x.Type<RedAddTypes>().Named("Red");
+                x.Type<GreenAddTypes>().Named("Green");
+                x.Type<BlueAddTypes>().Named("Blue");
+                x.Type<PurpleAddTypes>();
+            }));
+            // retrieve the instances by name
+            container.GetInstance<IAddTypes>("Red").IsType<RedAddTypes>();
+            container.GetInstance<IAddTypes>("Green").IsType<GreenAddTypes>();
+            container.GetInstance<IAddTypes>("Blue").IsType<BlueAddTypes>();
+        }
+        // ENDSAMPLE
+
+        [Test]
+        public void A_concrete_type_is_available_when_it_is_added_by_the_shorthand_mechanism()
+        {
+            IContainer container = new Container(registry => {
+                registry.For<IAddTypes>().AddInstances(x => {
+                    x.Type<RedAddTypes>();
+                    x.Type<GreenAddTypes>();
+                    x.Type<BlueAddTypes>();
+                    x.Type<PurpleAddTypes>();
+                });
+            });
+
+
+            container.GetAllInstances<IAddTypes>().Count().ShouldEqual(4);
+        }
+
+        [Test]
+        public void Make_sure_that_we_dont_double_dip_instances_when_we_register_a_type_with_a_name()
+        {
+            IContainer container = new Container(r => {
+                r.For<IAddTypes>().AddInstances(x => {
+                    x.Type<GreenAddTypes>();
+                    x.Type<BlueAddTypes>();
+                    x.Type<PurpleAddTypes>();
+                    x.Type<PurpleAddTypes>().Named("Purple");
+                });
+            });
+
+            container.GetAllInstances<IAddTypes>().Count().ShouldEqual(4);
+        }
+    }
+}

--- a/src/StructureMap.Docs/snippets/StructureMap.Testing/Configuration/DSL/RegistryTester.cs
+++ b/src/StructureMap.Docs/snippets/StructureMap.Testing/Configuration/DSL/RegistryTester.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using StructureMap.Configuration;
+using StructureMap.Configuration.DSL;
+using StructureMap.Graph;
+using StructureMap.Testing.Widget;
+using StructureMap.Testing.Widget3;
+
+namespace StructureMap.Testing.Configuration.DSL
+{
+    [TestFixture]
+    public class RegistryTester
+    {
+        #region Setup/Teardown
+
+        [SetUp]
+        public void SetUp()
+        {
+        }
+
+        #endregion
+
+        public class RedGreenRegistry : Registry
+        {
+            public RedGreenRegistry()
+            {
+                For<IWidget>().Add<ColorWidget>().Ctor<string>("color").Is("Red").Named(
+                    "Red");
+                For<IWidget>().Add<ColorWidget>().Ctor<string>("color").Is("Green").Named(
+                    "Green");
+            }
+        }
+
+        public class YellowBlueRegistry : Registry
+        {
+            public YellowBlueRegistry()
+            {
+                For<IWidget>().Add<ColorWidget>().Ctor<string>("color").Is("Yellow").Named(
+                    "Yellow");
+                For<IWidget>().Add<ColorWidget>().Ctor<string>("color").Is("Blue").Named(
+                    "Blue");
+            }
+        }
+
+        // SAMPLE: simple-registry
+        public class PurpleRegistry : Registry
+        {
+            public PurpleRegistry()
+            {
+                For<IWidget>().Use<AWidget>();
+            }
+        }
+        // ENDSAMPLE
+
+        [Test]
+        public void Can_add_an_instance_for_concrete_class_with_no_constructors()
+        {
+            var registry = new Registry();
+            registry.For<ConcreteWithNoConstructor>().Use(
+                c => ConcreteWithNoConstructor.Build());
+
+
+            var container = new Container(registry);
+            container.GetInstance<ConcreteWithNoConstructor>().ShouldNotBeNull();
+        }
+
+        [Test]
+        public void an_instance_of_the_base_registry_is_equal_to_itself()
+        {
+            var registry1 = new Registry();
+
+            registry1.Equals((object) registry1).ShouldBeTrue();
+        }
+
+        [Test]
+        public void two_instances_of_the_base_registry_type_are_not_considered_equal()
+        {
+            var registry1 = new Registry();
+            var registry2 = new Registry();
+
+            registry1.Equals((object) registry2).ShouldBeFalse();
+        }
+
+        [Test]
+        public void two_instances_of_a_public_derived_registry_type_are_considered_equal()
+        {
+            var registry1 = new TestRegistry();
+            var registry2 = new TestRegistry();
+            var registry3 = new TestRegistry2();
+            var registry4 = new TestRegistry2();
+
+            registry1.Equals((object) registry1).ShouldBeTrue();
+            registry1.Equals((object) registry2).ShouldBeTrue();
+            registry2.Equals((object) registry1).ShouldBeTrue();
+            registry3.Equals((object) registry4).ShouldBeTrue();
+
+            registry1.Equals((object) registry3).ShouldBeFalse();
+            registry3.Equals((object) registry1).ShouldBeFalse();
+        }
+
+        [Test]
+        public void two_instances_of_a_non_public_derived_registry_type_are_not_considered_equal()
+        {
+            var registry1 = new InternalTestRegistry();
+            var registry2 = new InternalTestRegistry();
+
+            registry1.Equals((object) registry1).ShouldBeTrue();
+            registry1.Equals((object) registry2).ShouldBeFalse();
+        }
+
+        // SAMPLE: including-registries
+        [Test]
+        public void include_a_registry()
+        {
+            var registry = new Registry();
+            registry.IncludeRegistry<YellowBlueRegistry>();
+            registry.IncludeRegistry<RedGreenRegistry>();
+            registry.IncludeRegistry<PurpleRegistry>();
+            // build a container
+            var container = new Container(registry);
+            // verify the default implementation and total registered implementations
+            container.GetInstance<IWidget>().ShouldBeOfType<AWidget>();
+            container.GetAllInstances<IWidget>().Count().ShouldEqual(5);
+        }
+        // ENDSAMPLE
+
+        public class MutatedWidget : IWidget
+        {
+            public void DoSomething()
+            {
+            }
+        }
+
+        public class MutatingRegistry : Registry
+        {
+            private static int count = 0;
+
+            public MutatingRegistry()
+            {
+                For<IWidget>().Use<AWidget>();
+
+                if (count++ >= 1)
+                {
+                    For<IWidget>().Use<MutatedWidget>();
+                }
+            }
+        }
+
+        [Test]
+        public void include_an_existing_registry_should_not_reevaluate_the_registry()
+        {
+            var registry1 = new Registry();
+            registry1.IncludeRegistry<MutatingRegistry>();
+
+            var registry2 = new Registry();
+            registry2.IncludeRegistry<MutatingRegistry>();
+
+            var container = new Container(config => {
+                config.AddRegistry(registry1);
+                config.AddRegistry(registry2);
+            });
+
+            container.GetInstance<IWidget>().ShouldBeOfType<AWidget>();
+        }
+
+
+        [Test]
+        public void Latch_on_a_PluginGraph()
+        {
+            var registry2 = new TestRegistry2();
+            var graph = new PluginGraph();
+
+            graph.Registries.Count.ShouldEqual(0);
+            registry2.ShouldBeOfType<IPluginGraphConfiguration>().Configure(graph);
+
+            graph.Registries.Contains(registry2).ShouldBeTrue();
+
+            registry2.ShouldBeOfType<IPluginGraphConfiguration>().Configure(graph);
+            registry2.ExecutedCount.ShouldEqual(1);
+        }
+
+        [Test]
+        public void use_the_basic_actions_as_part_of_building_a_PluginGraph()
+        {
+            var container = new Container(new BasicActionRegistry());
+            container.GetInstance<IGateway>().ShouldBeOfType<Fake3Gateway>();
+        }
+    }
+
+    public class ConcreteWithNoConstructor
+    {
+        private ConcreteWithNoConstructor()
+        {
+        }
+
+        public static ConcreteWithNoConstructor Build()
+        {
+            return new ConcreteWithNoConstructor();
+        }
+    }
+
+    public class TestRegistry : Registry
+    {
+    }
+
+    public class TestRegistry2 : Registry
+    {
+        private readonly int _count;
+
+        public TestRegistry2()
+        {
+            _count++;
+        }
+
+        public int ExecutedCount
+        {
+            get { return _count; }
+        }
+    }
+
+    internal class InternalTestRegistry : Registry
+    {
+    }
+
+
+    public class FakeGateway : IGateway
+    {
+        #region IGateway Members
+
+        public void DoSomething()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string WhoAmI
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        #endregion
+    }
+
+    public class Fake2Gateway : IGateway
+    {
+        #region IGateway Members
+
+        public void DoSomething()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string WhoAmI
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        #endregion
+    }
+
+    public class Fake3Gateway : IGateway
+    {
+        #region IGateway Members
+
+        public void DoSomething()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string WhoAmI
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        #endregion
+    }
+
+    public class BasicActionRegistry : Registry
+    {
+        public BasicActionRegistry()
+        {
+            registerAction(() => For<IGateway>().Use<Fake3Gateway>());
+        }
+    }
+}

--- a/src/StructureMap.Testing/Configuration/DSL/AddInstanceTester.cs
+++ b/src/StructureMap.Testing/Configuration/DSL/AddInstanceTester.cs
@@ -65,15 +65,16 @@ namespace StructureMap.Testing.Configuration.DSL
                 .Widget.IsType<AWidget>();
         }
 
+        // SAMPLE: named-instance
         [Test]
         public void SimpleCaseWithNamedInstance()
         {
             container = new Container(x => { x.For<IWidget>().Add<AWidget>().Named("MyInstance"); });
-
+            // retrieve an instance by name
             var widget = (AWidget) container.GetInstance<IWidget>("MyInstance");
             Assert.IsNotNull(widget);
         }
-
+        // ENDSAMPLE
 
         [Test]
         public void SpecifyANewInstanceOverrideADependencyWithANamedInstance()

--- a/src/StructureMap.Testing/Configuration/DSL/AddTypesTester.cs
+++ b/src/StructureMap.Testing/Configuration/DSL/AddTypesTester.cs
@@ -26,6 +26,7 @@ namespace StructureMap.Testing.Configuration.DSL
         {
         }
 
+        // SAMPLE: named-instances-shorthand
         [Test]
         public void A_concrete_type_is_available_by_name_when_it_is_added_by_the_shorthand_mechanism()
         {
@@ -35,11 +36,12 @@ namespace StructureMap.Testing.Configuration.DSL
                 x.Type<BlueAddTypes>().Named("Blue");
                 x.Type<PurpleAddTypes>();
             }));
-
+            // retrieve the instances by name
             container.GetInstance<IAddTypes>("Red").IsType<RedAddTypes>();
             container.GetInstance<IAddTypes>("Green").IsType<GreenAddTypes>();
             container.GetInstance<IAddTypes>("Blue").IsType<BlueAddTypes>();
         }
+        // ENDSAMPLE
 
         [Test]
         public void A_concrete_type_is_available_when_it_is_added_by_the_shorthand_mechanism()

--- a/src/StructureMap.Testing/Configuration/DSL/RegistryTester.cs
+++ b/src/StructureMap.Testing/Configuration/DSL/RegistryTester.cs
@@ -43,6 +43,7 @@ namespace StructureMap.Testing.Configuration.DSL
             }
         }
 
+        // SAMPLE: simple-registry
         public class PurpleRegistry : Registry
         {
             public PurpleRegistry()
@@ -50,7 +51,7 @@ namespace StructureMap.Testing.Configuration.DSL
                 For<IWidget>().Use<AWidget>();
             }
         }
-
+        // ENDSAMPLE
 
         [Test]
         public void Can_add_an_instance_for_concrete_class_with_no_constructors()
@@ -108,6 +109,7 @@ namespace StructureMap.Testing.Configuration.DSL
             registry1.Equals((object) registry2).ShouldBeFalse();
         }
 
+        // SAMPLE: including-registries
         [Test]
         public void include_a_registry()
         {
@@ -115,13 +117,13 @@ namespace StructureMap.Testing.Configuration.DSL
             registry.IncludeRegistry<YellowBlueRegistry>();
             registry.IncludeRegistry<RedGreenRegistry>();
             registry.IncludeRegistry<PurpleRegistry>();
-
+            // build a container
             var container = new Container(registry);
-
+            // verify the default implementation and total registered implementations
             container.GetInstance<IWidget>().ShouldBeOfType<AWidget>();
-
             container.GetAllInstances<IWidget>().Count().ShouldEqual(5);
         }
+        // ENDSAMPLE
 
         public class MutatedWidget : IWidget
         {


### PR DESCRIPTION
Here's my first take for the Registry DSL docs. They're heavily inspired from the [old docs](http://docs.structuremap.net/RegistryDSL.htm), but with snippets from real tests. Since other snippets were checked in, I added these, but it doesn't seem like they need to be there with the `fubudocs` command automatically pulling snippets in. I'm happy to go with either approach.

I did update the tests to replace blank lines with comments, because for some reason my browser showed any snippets with blank lines like this:
![tests-with-spaces](https://cloud.githubusercontent.com/assets/230004/2587214/19706c34-ba18-11e3-8d03-d8c9897d9ed3.PNG)
