### PR TITLE
Fix race condition in PluginGraph

### DIFF
--- a/src/StructureMap/Graph/PluginGraph.cs
+++ b/src/StructureMap/Graph/PluginGraph.cs
@@ -37,6 +37,7 @@ namespace StructureMap.Graph
 
 
     public class WeakReference<T>
+        where T : class
     {
         private readonly Func<T> _builder;
         private readonly WeakReference _reference;
@@ -51,12 +52,14 @@ namespace StructureMap.Graph
         {
             get
             {
-                if (!_reference.IsAlive)
+                var value = _reference.Target as T;
+                if (value == null)
                 {
-                    _reference.Target = _builder();
+                    value = _builder();
+                    _reference.Target = value;
                 }
 
-                return (T) _reference.Target;
+                return value;
             }
         }
     }


### PR DESCRIPTION
We've recentely gotten some strange NullReferenceException from StructureMap 2.6.4, now and then:

System.NullReferenceException: Object reference not set to an instance of an object.
   at StructureMap.Graph.AssemblyScanner.ScanForAll(PluginGraph pluginGraph)
   at StructureMap.Graph.PluginGraph.Seal()
   at StructureMap.PluginGraphBuilder.Build()
   ..(etc)

We have not been able to reproduce this error in our development, but after carefully going through the ScanForAll method of AssemblyScanner we suspect that the problem is in a race condition in the WeakReference class.

The problem is that _reference.IsAlive is checked, and then _reference.Target is returned. This is a classic case of race condition where garbage collection could occur in the meantime.

Why this occurs several times each day I don't know, but I have a theory that checking IsActive actually could trigger a context switch and garbage collection.
