### PR TITLE
Add `bundle install` step to the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,11 +5,15 @@ Getting StructureMap
 
 StructureMap is available via NuGet:
 
-    > Install-Package StructureMap
+```PowerShell
+Install-Package StructureMap
+```
 
-       -- or --
+or:
 
-    > ripple install StructureMap -p [your project name]
+```PowerShell
+ripple install StructureMap -p [your project name]
+```
 
 If you want to fix a bug or just want to tinker with an idea,
 we love receiving pull requests!
@@ -18,25 +22,29 @@ Building the Source
 -------------------
 
 1. Clone the repository: `git clone git://github.com/structuremap/structuremap.git`
-1. Make sure that you have got [Ruby installed][2] (>= 1.9.3).
+1. Make sure that you have got [Ruby][2] (>= 1.9.3) installed.
 1. If you are installing Ruby for the first time, run the following in command prompt at the root of the solution:
     1. `gem install bundler`
     2. `bundle install`
 1. In the root of the solution, run `rake` in the command prompt.
 1. Open `StructureMap.sln` in VS2012 (`rake sln` from the root as well).
 
-A copy of the [StructureMap website and documentation][3] is in the `StructureMap.Docs` folder.  To run the documentation website, run ``rake fubudocs:run` or `fubudocs run -o` in the command prompt.
+A copy of the [StructureMap website and documentation][3] is
+in the `StructureMap.Docs` folder.  To run the documentation
+website, run ``rake fubudocs:run` or `fubudocs run -o` in the
+command prompt.
 
-Please post any questions or bugs to the [StructureMap Users mailing list][4].
+Please post any questions or bugs to the
+[StructureMap Users mailing list][4].
 
-The latest code and documentation is available on the [main site][5]
- and on [Fubuworld][6].
+The latest code and documentation is available on the
+[main site][5] and on [Fubuworld][6].
 
 Thanks for trying StructureMap.
 
- [1]: http://docs.structuremap.net/InversionOfControl.htm
- [2]: http://www.ruby-lang.org/en/downloads/
- [3]: http://docs.structuremap.net/
- [4]: http://groups.google.com/group/structuremap-users
- [5]: http://structuremap.net/
- [6]: http://fubuworld.com/structuremap
+[1]: http://docs.structuremap.net/InversionOfControl.htm
+[2]: http://www.ruby-lang.org/en/downloads/
+[3]: http://docs.structuremap.net/
+[4]: http://groups.google.com/group/structuremap-users
+[5]: http://structuremap.net/
+[6]: http://fubuworld.com/structuremap


### PR DESCRIPTION
When getting the project up and running for the first time, I got the following error after performing the steps in the README:

```
rake aborted!
cannot load such file -- fuburake
```

I think there's a `bundle install` step missing from the README that I at least had to run before `rake` would do anything meaningful. This pull request adds that step and a couple of other touches to the README file.
