### PR TITLE
Removed extraneous accent in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ Building the Source
 
 A copy of the [StructureMap website and documentation][3] is
 in the `StructureMap.Docs` folder.  To run the documentation
-website, run ``rake fubudocs:run` or `fubudocs run -o` in the
+website, run `rake fubudocs:run` or `fubudocs run -o` in the
 command prompt.
 
 Please post any questions or bugs to the


### PR DESCRIPTION
Noticed I had an extraneous accent in the README. This pull request removes it.
