### PR TITLE
False Positive Bi-directional Dependency Relationship Errors

### DIFF
--- a/src/StructureMap/Pipeline/LifecycleObjectCache.cs
+++ b/src/StructureMap/Pipeline/LifecycleObjectCache.cs
@@ -52,11 +52,11 @@ namespace StructureMap.Pipeline
             _lock.EnterUpgradeableReadLock();
             try
             {
-				if (_instances.Contains(instance))
-				{
-					throw new StructureMapBuildException("Bi-directional dependency relationship detected!" +
-														 Environment.NewLine + "Check the StructureMap stacktrace below:");
-				}
+                if (_instances.Contains(instance))
+                {
+                    throw new StructureMapBuildException("Bi-directional dependency relationship detected!" +
+                                                         Environment.NewLine + "Check the StructureMap stacktrace below:");
+                }
 
                 if (_objects.ContainsKey(key))
                 {


### PR DESCRIPTION
When the object being requested takes a long time to build, the code can throw a false positive error message about a bi-directional dependency. This should mitigate that problem.
