### PR TITLE
AutoMocking containers no longer create mock objects for concrete types....

### DIFF
--- a/src/StructureMap.AutoMocking.Moq.Testing/AutoMockerTester.cs
+++ b/src/StructureMap.AutoMocking.Moq.Testing/AutoMockerTester.cs
@@ -13,6 +13,11 @@ namespace StructureMap.AutoMocking.Moq.Testing
         protected abstract void setExpectation<T, TResult>(T mock, Expression<Func<T, TResult>> functionCall,
                                                            TResult expectedResult) where T : class;
 
+	    public class ConcreteThingWithNoConstructor
+	    {
+		    
+	    }
+
         public class ConcreteThing
         {
             private readonly IMockedService _service;
@@ -218,5 +223,15 @@ namespace StructureMap.AutoMocking.Moq.Testing
             setExpectation(concreteClass, x => x.Name, "Max");
             concreteClass.Name.ShouldEqual("Max");
         }
+
+		[Test]
+	    public void GetTheConcreteTypeFromTheMockerWhenTypeHasNoConstructorArguments()
+		{
+			AutoMocker<ConcreteThingWithNoConstructor> autoMocker = createAutoMocker<ConcreteThingWithNoConstructor>();
+
+			var thing = autoMocker.ClassUnderTest;
+
+			thing.GetType().ShouldEqual(typeof (ConcreteThingWithNoConstructor));
+		}
     }
 }

--- a/src/StructureMap.AutoMocking.Testing/RhinoAutoMockerTester.cs
+++ b/src/StructureMap.AutoMocking.Testing/RhinoAutoMockerTester.cs
@@ -94,7 +94,7 @@ namespace StructureMap.AutoMocking.Testing
             autoMocker.Get<IMockedService>().AssertWasCalled(s => s.Go());
         }
 
-        [Test]
+        [Test, Ignore("This behavior is inconsistent with SM 2.6.x.")]
         public void use_a_mock_object_for_concrete_class_dependency()
         {
             var autoMocker = new RhinoAutoMocker<ClassThatUsesConcreteDependency>();

--- a/src/StructureMap/AutoMocking/AutoMockedContainer.cs
+++ b/src/StructureMap/AutoMocking/AutoMockedContainer.cs
@@ -28,7 +28,7 @@ namespace StructureMap.AutoMocking
 
         public PluginFamily Build(Type pluginType)
         {
-            if (pluginType.IsConcrete() && pluginType.GetConstructors().All(x => x.GetParameters().Count() != 0))
+            if (pluginType.IsConcrete())
             {
                 return null;
             }


### PR DESCRIPTION
...  Fixes #280.

But... there was a RhinoAutoMocker spec that tests specifically _for_ this behavior, even though this behavior is a breaking change from 3.0.  I disabled the RhinoAutoMocker spec for now.  I also noticed a _lot_ of churn in the code in this area lately.  Maybe this needs a different fix, but at this point, I'm not sure what the intended behavior actually is.  
