### PR TITLE
Plugin family referencing plugin family

### DIFF
--- a/src/StructureMap.Testing/Configuration/DSL/CreatePluginFamilyTester.cs
+++ b/src/StructureMap.Testing/Configuration/DSL/CreatePluginFamilyTester.cs
@@ -20,7 +20,19 @@ namespace StructureMap.Testing.Configuration.DSL
 
         #endregion
 
+        public interface SomethingElseEntirely : Something, SomethingElse
+        {
+        }
+
+        public interface SomethingElse
+        {
+        }
+
         public interface Something
+        {
+        }
+
+        public class OrangeSomething : SomethingElseEntirely
         {
         }
 
@@ -169,6 +181,19 @@ namespace StructureMap.Testing.Configuration.DSL
             });
 
             container.GetInstance<IWidget>().ShouldBeOfType<ColorWidget>().Color.ShouldEqual("Red");
+        }
+
+        [Test]
+        public void CreatePluginFamilyWithReferenceToAnotherFamily()
+        {
+            var container = new Container(r =>
+            {
+                r.For<SomethingElseEntirely>().Use<OrangeSomething>();
+                r.For<SomethingElse>().Use(context => context.GetInstance<SomethingElseEntirely>());
+                r.For<Something>().Use(context => context.GetInstance<SomethingElseEntirely>());
+            });
+
+            container.GetInstance<SomethingElseEntirely>().ShouldBeOfType<OrangeSomething>();
         }
 
         [Test]

--- a/src/StructureMap.Testing/Configuration/DSL/CreatePluginFamilyTester.cs
+++ b/src/StructureMap.Testing/Configuration/DSL/CreatePluginFamilyTester.cs
@@ -189,11 +189,22 @@ namespace StructureMap.Testing.Configuration.DSL
             var container = new Container(r =>
             {
                 r.For<SomethingElseEntirely>().Use<OrangeSomething>();
-                r.For<SomethingElse>().Use(context => context.GetInstance<SomethingElseEntirely>());
-                r.For<Something>().Use(context => context.GetInstance<SomethingElseEntirely>());
+                r.For<SomethingElse>().Use(context =>
+                    // If the return is cast to OrangeSomething, this works.
+                    context.GetInstance<SomethingElseEntirely>());
+                r.For<Something>().Use(context => 
+                    // If the return is cast to OrangeSomething, this works.
+                    context.GetInstance<SomethingElseEntirely>());
             });
 
-            container.GetInstance<SomethingElseEntirely>().ShouldBeOfType<OrangeSomething>();
+            var orangeSomething = container.GetInstance<SomethingElseEntirely>();
+            orangeSomething.ShouldBeOfType<OrangeSomething>();
+            container.GetInstance<SomethingElse>()
+                .ShouldBeOfType<OrangeSomething>()
+                .ShouldEqual(orangeSomething);
+            container.GetInstance<Something>()
+                .ShouldBeOfType<OrangeSomething>()
+                .ShouldEqual(orangeSomething);
         }
 
         [Test]


### PR DESCRIPTION
This PR contains a failing test that would be neat if was fixed. To get around it now, one has to cast the object to the concrete implementation, since `LambdaInstance<T>.ReturnedType` only returns `typeof(T)` and does not actually investigate what `context.GetInstance<T>()` might resolve to.

On top of this, instead of throwing an exception that states that the `ReturnedType` needs to be a concrete type (as verified in `TypeExtensions.CanBeCastTo():174`), StructureMap fails with an exception stating that the returned type can't be cast to the plugin family, which is actually false.

If it's not possible to fix the test, a new test should be created that verifies the exception that is thrown so it can be made more understandable.