### PR TITLE
Do a Get/Lock/Get to avoid thread serialization

### DIFF
--- a/src/StructureMap/Pipeline/ObjectBuilder.cs
+++ b/src/StructureMap/Pipeline/ObjectBuilder.cs
@@ -30,9 +30,14 @@ namespace StructureMap.Pipeline
         public object Resolve(Type pluginType, Instance instance, BuildSession session)
         {
             IObjectCache cache = FindCache(pluginType, instance, session);
+
+            object returnValue = cache.Get(pluginType, instance);
+            if (returnValue != null)
+                return returnValue;
+
             lock (cache.Locker)
             {
-                object returnValue = cache.Get(pluginType, instance);
+                returnValue = cache.Get(pluginType, instance);
                 if (returnValue == null)
                 {
                     returnValue = ConstructNew(pluginType, instance, session);


### PR DESCRIPTION
In StructureMap.Pipeline.ObjectBuilder.Resolve I have several web applications that have been experiencing lock contention in this method as it takes a lock before checking the cache, effectively allowing only one thread at a time to GetInstance<T> from StructureMap.
