### PR TITLE
Fixed issue where StructureMap.Net4 was not being signed

### DIFF
--- a/src/StructureMap.Net4/StructureMap.Net4.csproj
+++ b/src/StructureMap.Net4/StructureMap.Net4.csproj
@@ -17,6 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
+    <SignAssembly>false</SignAssembly>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -25,6 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
+    <SignAssembly>false</SignAssembly>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -42,6 +44,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\ReleaseSign\StructureMap.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\structuremap.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -61,6 +66,11 @@
       <Project>{3f36ea80-2f9a-4dad-ba27-5ac6163a2ee3}</Project>
       <Name>StructureMap</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\structuremap.snk">
+      <Link>structuremap.snk</Link>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/StructureMap.sln
+++ b/src/StructureMap.sln
@@ -75,9 +75,9 @@ Global
 		{3F36EA80-2F9A-4DAD-BA27-5AC6163A2EE3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3F36EA80-2F9A-4DAD-BA27-5AC6163A2EE3}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{3F36EA80-2F9A-4DAD-BA27-5AC6163A2EE3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{3F36EA80-2F9A-4DAD-BA27-5AC6163A2EE3}.ReleaseSign|.NET.ActiveCfg = Release|Any CPU
-		{3F36EA80-2F9A-4DAD-BA27-5AC6163A2EE3}.ReleaseSign|Any CPU.ActiveCfg = Release|Any CPU
-		{3F36EA80-2F9A-4DAD-BA27-5AC6163A2EE3}.ReleaseSign|Any CPU.Build.0 = Release|Any CPU
+		{3F36EA80-2F9A-4DAD-BA27-5AC6163A2EE3}.ReleaseSign|.NET.ActiveCfg = ReleaseSign|Any CPU
+		{3F36EA80-2F9A-4DAD-BA27-5AC6163A2EE3}.ReleaseSign|Any CPU.ActiveCfg = ReleaseSign|Any CPU
+		{3F36EA80-2F9A-4DAD-BA27-5AC6163A2EE3}.ReleaseSign|Any CPU.Build.0 = ReleaseSign|Any CPU
 		{3F36EA80-2F9A-4DAD-BA27-5AC6163A2EE3}.ReleaseSign|Mixed Platforms.ActiveCfg = ReleaseSign|Any CPU
 		{3F36EA80-2F9A-4DAD-BA27-5AC6163A2EE3}.ReleaseSign|Mixed Platforms.Build.0 = ReleaseSign|Any CPU
 		{63C2742D-B6E2-484F-AFDB-346873075C5E}.Build|.NET.ActiveCfg = Release|Any CPU
@@ -363,9 +363,9 @@ Global
 		{6D812B81-CF2E-4DF1-9F73-BC19E5A6A019}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6D812B81-CF2E-4DF1-9F73-BC19E5A6A019}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{6D812B81-CF2E-4DF1-9F73-BC19E5A6A019}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{6D812B81-CF2E-4DF1-9F73-BC19E5A6A019}.ReleaseSign|.NET.ActiveCfg = Release|Any CPU
-		{6D812B81-CF2E-4DF1-9F73-BC19E5A6A019}.ReleaseSign|Any CPU.ActiveCfg = Release|Any CPU
-		{6D812B81-CF2E-4DF1-9F73-BC19E5A6A019}.ReleaseSign|Any CPU.Build.0 = Release|Any CPU
+		{6D812B81-CF2E-4DF1-9F73-BC19E5A6A019}.ReleaseSign|.NET.ActiveCfg = ReleaseSign|Any CPU
+		{6D812B81-CF2E-4DF1-9F73-BC19E5A6A019}.ReleaseSign|Any CPU.ActiveCfg = ReleaseSign|Any CPU
+		{6D812B81-CF2E-4DF1-9F73-BC19E5A6A019}.ReleaseSign|Any CPU.Build.0 = ReleaseSign|Any CPU
 		{6D812B81-CF2E-4DF1-9F73-BC19E5A6A019}.ReleaseSign|Mixed Platforms.ActiveCfg = ReleaseSign|Any CPU
 		{6D812B81-CF2E-4DF1-9F73-BC19E5A6A019}.ReleaseSign|Mixed Platforms.Build.0 = ReleaseSign|Any CPU
 		{DCDB6C5F-8D8A-4542-8F50-1A72E4D883E8}.Build|.NET.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
When building in ReleaseSign configuration StructureMap.Net4 was not
signing the assembly because it did not have reference to the snk file.
Added a reference to the snk file and ensured that all build
configurations worked properly.