### PR TITLE
Assembly scanning: Use .exe suffix when scanning for exe files

### DIFF
--- a/src/StructureMap.Net4/AssemblyFinder.cs
+++ b/src/StructureMap.Net4/AssemblyFinder.cs
@@ -8,7 +8,7 @@ namespace StructureMap.Graph
 {
     public static class AssemblyFinder
     {
-        public static IEnumerable<Assembly> FindAssemblies(Action<string> logFailure)
+        public static IEnumerable<Assembly> FindAssemblies(Action<string> logFailure, bool includeExeFiles)
         {
             var assemblyPath = AppDomain.CurrentDomain.BaseDirectory;
             var binPath = FindBinPath();
@@ -18,15 +18,20 @@ namespace StructureMap.Graph
             }
 
 
-            return FindAssemblies(assemblyPath, logFailure);
+            return FindAssemblies(assemblyPath, logFailure, includeExeFiles);
         }
 
-        public static IEnumerable<Assembly> FindAssemblies(string assemblyPath, Action<string> logFailure)
+        public static IEnumerable<Assembly> FindAssemblies(string assemblyPath, Action<string> logFailure, bool includeExeFiles)
         {
             var dllFiles = Directory.EnumerateFiles(assemblyPath, "*.dll", SearchOption.AllDirectories);
-            var exeFiles = Directory.EnumerateFiles(assemblyPath, "*.exe", SearchOption.AllDirectories);
+            var files = dllFiles;
 
-            var files = dllFiles.Concat(exeFiles);
+            if(includeExeFiles)
+            {
+                var exeFiles = Directory.EnumerateFiles(assemblyPath, "*.exe", SearchOption.AllDirectories);
+                files = dllFiles.Concat(exeFiles);
+            }
+
             foreach (var file in files)
             {
                 var name = Path.GetFileNameWithoutExtension(file);
@@ -60,14 +65,14 @@ namespace StructureMap.Graph
 
 
         public static IEnumerable<Assembly> FindAssemblies(Func<Assembly, bool> filter,
-            Action<string> onDirectoryFound = null)
+            Action<string> onDirectoryFound = null, bool includeExeFiles=false)
         {
             if (onDirectoryFound == null)
             {
                 onDirectoryFound = dir => { };
             }
 
-            return FindAssemblies(file => { }).Where(filter);
+            return FindAssemblies(file => { }, includeExeFiles: includeExeFiles).Where(filter);
         }
 
 

--- a/src/StructureMap.Net4/AssemblyFinder.cs
+++ b/src/StructureMap.Net4/AssemblyFinder.cs
@@ -8,11 +8,6 @@ namespace StructureMap.Graph
 {
     public static class AssemblyFinder
     {
-        public static IEnumerable<Assembly> FindDependentAssemblies()
-        {
-            return FindAssemblies(file => { }).Where(x => x.GetReferencedAssemblies().Any(assem => assem.Name == "FubuMVC.Core"));
-        }
-
         public static IEnumerable<Assembly> FindAssemblies(Action<string> logFailure)
         {
             var assemblyPath = AppDomain.CurrentDomain.BaseDirectory;

--- a/src/StructureMap.Net4/AssemblyFinder.cs
+++ b/src/StructureMap.Net4/AssemblyFinder.cs
@@ -29,7 +29,7 @@ namespace StructureMap.Graph
         public static IEnumerable<Assembly> FindAssemblies(string assemblyPath, Action<string> logFailure)
         {
             var dllFiles = Directory.EnumerateFiles(assemblyPath, "*.dll", SearchOption.AllDirectories);
-            var exeFiles = Directory.EnumerateFiles(assemblyPath, "*.dll", SearchOption.AllDirectories);
+            var exeFiles = Directory.EnumerateFiles(assemblyPath, "*.exe", SearchOption.AllDirectories);
 
             var files = dllFiles.Concat(exeFiles);
             foreach (var file in files)

--- a/src/StructureMap.Net4/AssemblyScannerExtensions.cs
+++ b/src/StructureMap.Net4/AssemblyScannerExtensions.cs
@@ -19,17 +19,17 @@ namespace StructureMap.Graph
             }
         }
 
-        public static void AssembliesFromApplicationBaseDirectory(this IAssemblyScanner scanner)
+        public static void AssembliesFromApplicationBaseDirectory(this IAssemblyScanner scanner, bool includeExeFiles = false)
         {
-            scanner.AssembliesFromApplicationBaseDirectory(a => true);
+            scanner.AssembliesFromApplicationBaseDirectory(a => true, includeExeFiles: includeExeFiles);
         }
 
-        public static void AssembliesFromApplicationBaseDirectory(this IAssemblyScanner scanner, Func<Assembly, bool> assemblyFilter)
+        public static void AssembliesFromApplicationBaseDirectory(this IAssemblyScanner scanner, Func<Assembly, bool> assemblyFilter, bool includeExeFiles = false)
         {
             var assemblies = AssemblyFinder.FindAssemblies(assemblyFilter, txt =>
             {
                 Console.WriteLine("StructureMap could not load assembly from file " + txt);
-            });
+            }, includeExeFiles: includeExeFiles);
 
             foreach (var assembly in assemblies)
             {
@@ -37,12 +37,12 @@ namespace StructureMap.Graph
             }
         }
 
-        public static void AssembliesFromPath(this IAssemblyScanner scanner, string path)
+        public static void AssembliesFromPath(this IAssemblyScanner scanner, string path, bool includeExeFiles=false)
         {
             var assemblies = AssemblyFinder.FindAssemblies(path, txt =>
             {
                 Console.WriteLine("StructureMap could not load assembly from file " + txt);
-            });
+            }, includeExeFiles: includeExeFiles);
 
             foreach (var assembly in assemblies)
             {
@@ -51,12 +51,12 @@ namespace StructureMap.Graph
         }
 
         public static void AssembliesFromPath(this IAssemblyScanner scanner, string path,
-            Func<Assembly, bool> assemblyFilter)
+            Func<Assembly, bool> assemblyFilter, bool includeExeFiles = false)
         {
             var assemblies = AssemblyFinder.FindAssemblies(path, txt =>
             {
                 Console.WriteLine("StructureMap could not load assembly from file " + txt);
-            }).Where(assemblyFilter);
+            }, includeExeFiles: includeExeFiles).Where(assemblyFilter);
 
 
             foreach (var assembly in assemblies)

--- a/src/StructureMap.Testing.ExeWidget/AssemblyInfo.cs
+++ b/src/StructureMap.Testing.ExeWidget/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitle("StructureMap.Testing.ExeWidget")]

--- a/src/StructureMap.Testing.ExeWidget/IDefinedInExe.cs
+++ b/src/StructureMap.Testing.ExeWidget/IDefinedInExe.cs
@@ -1,0 +1,7 @@
+﻿
+namespace StructureMap.Testing.ExeWidget
+{
+    public interface IDefinedInExe
+    {
+    }
+}

--- a/src/StructureMap.Testing.ExeWidget/Program.cs
+++ b/src/StructureMap.Testing.ExeWidget/Program.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StructureMap.Testing.ExeWidget
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/src/StructureMap.Testing.ExeWidget/StructureMap.Testing.ExeWidget.csproj
+++ b/src/StructureMap.Testing.ExeWidget/StructureMap.Testing.ExeWidget.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3001815E-2766-44D6-AFA1-8FD8F4C400D9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>StructureMap.Testing.ExeWidget</RootNamespace>
+    <AssemblyName>StructureMap.Testing.ExeWidget</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="IDefinedInExe.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/StructureMap.Testing/Graph/AssemblyScannerTester.cs
+++ b/src/StructureMap.Testing/Graph/AssemblyScannerTester.cs
@@ -12,6 +12,7 @@ using StructureMap.Testing.Widget;
 using StructureMap.Testing.Widget3;
 using StructureMap.Testing.Widget5;
 using StructureMap.TypeRules;
+using StructureMap.Testing.ExeWidget;
 
 namespace StructureMap.Testing.Graph
 {
@@ -56,9 +57,11 @@ namespace StructureMap.Testing.Graph
 
             var assembly1 = typeof (RedGreenRegistry).Assembly.Location;
             var assembly2 = typeof (IWorker).Assembly.Location;
+            var assembly3 = typeof(IDefinedInExe).Assembly.Location;
 
             File.Copy(assembly1, Path.Combine(assemblyScanningFolder, Path.GetFileName(assembly1)), true);
             File.Copy(assembly2, Path.Combine(assemblyScanningFolder, Path.GetFileName(assembly2)), true);
+            File.Copy(assembly3, Path.Combine(assemblyScanningFolder, Path.GetFileName(assembly3)), true);
         }
 
         private PluginGraph theGraph;
@@ -146,6 +149,7 @@ namespace StructureMap.Testing.Graph
             Scan(x => x.AssembliesFromPath(assemblyScanningFolder));
             shouldHaveFamilyWithSameName<IInterfaceInWidget5>();
             shouldHaveFamilyWithSameName<IWorker>();
+            shouldNotHaveFamilyWithSameName<IDefinedInExe>();
         }
 
         [Test]
@@ -154,9 +158,28 @@ namespace StructureMap.Testing.Graph
             Scan(x => x.AssembliesFromApplicationBaseDirectory());
             shouldHaveFamilyWithSameName<IInterfaceInWidget5>();
             shouldHaveFamilyWithSameName<IWorker>();
+            shouldNotHaveFamilyWithSameName<IDefinedInExe>();
+        }
+        // ENDSAMPLE
+
+        [Test]
+        public void scan_all_assemblies_in_a_folder_including_exe()
+        {
+            Scan(x => x.AssembliesFromPath(assemblyScanningFolder, includeExeFiles: true));
+            shouldHaveFamilyWithSameName<IInterfaceInWidget5>();
+            shouldHaveFamilyWithSameName<IWorker>();
+            shouldHaveFamilyWithSameName<IDefinedInExe>();
         }
 
-        // ENDSAMPLE
+        [Test]
+        public void scan_all_assemblies_in_application_base_directory_including_exe()
+        {
+            Scan(x => x.AssembliesFromApplicationBaseDirectory(includeExeFiles: true));
+            shouldHaveFamilyWithSameName<IInterfaceInWidget5>();
+            shouldHaveFamilyWithSameName<IWorker>();
+            shouldHaveFamilyWithSameName<IDefinedInExe>();
+        }
+
 
         // SAMPLE: scan-calling-assembly
         [Test]

--- a/src/StructureMap.Testing/StructureMap.Testing.csproj
+++ b/src/StructureMap.Testing/StructureMap.Testing.csproj
@@ -111,6 +111,10 @@
       <Project>{6d812b81-cf2e-4df1-9f73-bc19e5a6a019}</Project>
       <Name>StructureMap.Net4</Name>
     </ProjectReference>
+    <ProjectReference Include="..\StructureMap.Testing.ExeWidget\StructureMap.Testing.ExeWidget.csproj">
+      <Project>{3001815e-2766-44d6-afa1-8fd8f4c400d9}</Project>
+      <Name>StructureMap.Testing.ExeWidget</Name>
+    </ProjectReference>
     <ProjectReference Include="..\StructureMap.Web\StructureMap.Web.csproj">
       <Project>{fa8fdbc9-46ed-4976-a554-a5a1079bd765}</Project>
       <Name>StructureMap.Web</Name>

--- a/src/StructureMap.sln
+++ b/src/StructureMap.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{93877CE0-BA48-4F28-B372-B8E802CEE085}"
 EndProject
@@ -39,6 +39,8 @@ EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "StructureMap.Shared", "StructureMap.Shared\StructureMap.Shared.shproj", "{6EB495CA-A997-452B-B113-60B8FDC432EA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StructureMap.Dotnet", "StructureMap.Dotnet\StructureMap.Dotnet.csproj", "{57144C5D-7614-45EA-8F8E-07C62709FEA9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StructureMap.Testing.ExeWidget", "StructureMap.Testing.ExeWidget\StructureMap.Testing.ExeWidget.csproj", "{3001815E-2766-44D6-AFA1-8FD8F4C400D9}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -456,6 +458,36 @@ Global
 		{57144C5D-7614-45EA-8F8E-07C62709FEA9}.ReleaseSign|Any CPU.Build.0 = Release|Any CPU
 		{57144C5D-7614-45EA-8F8E-07C62709FEA9}.ReleaseSign|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{57144C5D-7614-45EA-8F8E-07C62709FEA9}.ReleaseSign|Mixed Platforms.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Build|.NET.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Build|.NET.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Build|Any CPU.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Build|Any CPU.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Build|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Build|Mixed Platforms.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Debug|.NET.ActiveCfg = Debug|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Debug|.NET.Build.0 = Debug|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.NET45WP8|.NET.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.NET45WP8|.NET.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.NET45WP8|Any CPU.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.NET45WP8|Any CPU.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.NET45WP8|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.NET45WP8|Mixed Platforms.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Release|.NET.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Release|.NET.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.ReleaseSign|.NET.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.ReleaseSign|.NET.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.ReleaseSign|Any CPU.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.ReleaseSign|Any CPU.Build.0 = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.ReleaseSign|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9}.ReleaseSign|Mixed Platforms.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -468,5 +500,6 @@ Global
 		{CAB97F7F-FB75-410C-898A-88DCAAC036BE} = {E1C10209-160D-4054-ACB7-478A9FDCF84C}
 		{C205EA4C-4CD0-4221-A3CB-AFD835F0B263} = {E1C10209-160D-4054-ACB7-478A9FDCF84C}
 		{DCDB6C5F-8D8A-4542-8F50-1A72E4D883E8} = {E1C10209-160D-4054-ACB7-478A9FDCF84C}
+		{3001815E-2766-44D6-AFA1-8FD8F4C400D9} = {E1C10209-160D-4054-ACB7-478A9FDCF84C}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Took a while before we figured out why a refactoring broke our DI: exe files are not scanned when using `AssembliesFromApplicationBaseDirectory`.

Looks like `StructureMap.Graph.AssemblyFinder.FindAssemblies` has a typo:

    var exeFiles = Directory.EnumerateFiles(assemblyPath, "*.dll", SearchOption.AllDirectories);
