### PR TITLE
Test case for bug: OnCreation is not called for inline dependencies

### DIFF
--- a/src/StructureMap.Testing/Bugs/oncreation_doesnt_work_for_inline_dependencies.cs
+++ b/src/StructureMap.Testing/Bugs/oncreation_doesnt_work_for_inline_dependencies.cs
@@ -1,0 +1,43 @@
+﻿using NUnit.Framework;
+using StructureMap.Configuration.DSL;
+
+namespace StructureMap.Testing.Bugs
+{
+    public class OnCreation_doesnt_work_for_inline_dependencies
+    {
+        [Test]
+        public void should_call_OnCreation_for_regstered_inline_dependencies()
+        {
+            Container.For<TheRegistry>().GetInstance<IRootType>();
+            Dependency.StuffWasDone.ShouldBeTrue();
+        }
+
+        public class TheRegistry : Registry
+        {
+            public TheRegistry()
+            {
+                For<IRootType>().Use<RootType>()
+                    .Ctor<IDependency>().Is<Dependency>(x => x.OnCreation(y => y.DoStuff()));
+            }
+        }
+
+        public interface IRootType { }
+        public class RootType : IRootType
+        {
+            public RootType(IDependency dependency)
+            {
+            }
+        }
+
+        public interface IDependency { }
+        public class Dependency : IDependency
+        {
+            public static bool StuffWasDone;
+
+            public void DoStuff()
+            {
+                StuffWasDone = true;
+            }
+        }
+    }
+}

--- a/src/StructureMap.Testing/StructureMap.Testing.csproj
+++ b/src/StructureMap.Testing/StructureMap.Testing.csproj
@@ -235,6 +235,7 @@
     <Compile Include="Bugs\LambdaCreatesNullBugTester.cs" />
     <Compile Include="Bugs\MemoryLeak_bug_289.cs" />
     <Compile Include="Bugs\MixedConfigureAndInitializeMissingInstanceProblem.cs" />
+    <Compile Include="Bugs\OnCreation_doesnt_work_for_inline_dependencies.cs" />
     <Compile Include="Bugs\OpenGenericWithConstraints.cs" />
     <Compile Include="Bugs\Register_Lambda_against_Type_Bug_274.cs" />
     <Compile Include="Bugs\ScanIndexerBugTester.cs" />


### PR DESCRIPTION
This is the simplest reproduction I could come up with.

This test passes on 2.6, but fails on 3.1 and 4.0 - `OnCreation` handler is not called for dependencies registered inline.