### PR TITLE
make IsInNamespace return false when one namespace starts with another, but is not its subnamespace (e.g. "abcd" and "abc")

### DIFF
--- a/src/StructureMap.Shared/TypeExtensions.cs
+++ b/src/StructureMap.Shared/TypeExtensions.cs
@@ -73,7 +73,8 @@ namespace StructureMap.TypeRules
 
         public static bool IsInNamespace(this Type type, string nameSpace)
         {
-            return type.Namespace != null && type.Namespace.StartsWith(nameSpace);
+            var subNameSpace = nameSpace + ".";
+            return type.Namespace != null && (type.Namespace.Equals(nameSpace) || type.Namespace.StartsWith(subNameSpace));
         }
 
         public static bool IsOpenGeneric(this Type type)

--- a/src/StructureMap.Testing/Graph/AssemblyScannerTester.cs
+++ b/src/StructureMap.Testing/Graph/AssemblyScannerTester.cs
@@ -117,9 +117,12 @@ namespace StructureMap.Testing.Graph
         public void is_in_namespace()
         {
             GetType().IsInNamespace("blah").ShouldBeFalse();
+            GetType().IsInNamespace("Struct").ShouldBeFalse();
             GetType().IsInNamespace("StructureMap").ShouldBeTrue();
+            GetType().IsInNamespace("StructureMap.Test").ShouldBeFalse();
             GetType().IsInNamespace("StructureMap.Testing").ShouldBeTrue();
             GetType().IsInNamespace("StructureMap.Testing.Graph").ShouldBeTrue();
+            GetType().IsInNamespace("StructureMap.Testing.Graphics").ShouldBeFalse();
             GetType().IsInNamespace("StructureMap.Testing.Graph.Something").ShouldBeFalse();
 
             var _person = new


### PR DESCRIPTION
This fixes an issue where a type is incorrectly recognized as being in a namespace when it actually isn't.