### PR TITLE
Nested registries do not seem to respect the order types are registered

### DIFF
--- a/src/StructureMap.Dotnet/StructureMap.Dotnet.nuget.targets
+++ b/src/StructureMap.Dotnet/StructureMap.Dotnet.nuget.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
-    <NuGetPackageRoot>C:\Users\jeremill\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
     <Import Project="$(NuGetPackageRoot)\NuSpec.ReferenceGenerator\1.0.0\build\dotnet\NuSpec.ReferenceGenerator.targets" Condition="Exists('$(NuGetPackageRoot)\NuSpec.ReferenceGenerator\1.0.0\build\dotnet\NuSpec.ReferenceGenerator.targets')" />

--- a/src/StructureMap.Net4/AssemblyFinder.cs
+++ b/src/StructureMap.Net4/AssemblyFinder.cs
@@ -82,7 +82,5 @@ namespace StructureMap.Graph
 
             return FindAssemblies(file => { }, includeExeFiles: includeExeFiles).Where(filter);
         }
-
-
     }
 }

--- a/src/StructureMap.Shared/Graph/FindRegistriesScanner.cs
+++ b/src/StructureMap.Shared/Graph/FindRegistriesScanner.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using StructureMap.Configuration.DSL;
+
 using StructureMap.Graph.Scanning;
 
 namespace StructureMap.Graph
@@ -11,7 +11,6 @@ namespace StructureMap.Graph
             types.FindTypes(TypeClassification.Closed | TypeClassification.Concretes)
                 .Where(Registry.IsPublicRegistry)
                 .Each(type => registry.Configure(x => x.ImportRegistry(type)));
-
         }
     }
 }

--- a/src/StructureMap.Shared/PluginGraphBuilder.cs
+++ b/src/StructureMap.Shared/PluginGraphBuilder.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using StructureMap.Configuration.DSL;
+
 using StructureMap.Graph;
 
 namespace StructureMap
@@ -67,7 +67,6 @@ namespace StructureMap
 
                 scanning.Each(x => _graph.ImportRegistry(x.Result));
             }
-
 
             if (_graph.QueuedRegistries.Any())
             {

--- a/src/StructureMap.Shared/Registry.cs
+++ b/src/StructureMap.Shared/Registry.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using StructureMap.Building.Interception;
@@ -27,7 +26,7 @@ namespace StructureMap
     /// </example>
     public class Registry : IRegistry
     {
-        private readonly List<Action<PluginGraph>> _actions = new List<Action<PluginGraph>>();
+        private readonly IList<Action<PluginGraph>> _actions = new List<Action<PluginGraph>>();
 
         internal readonly IList<AssemblyScanner> Scanners = new List<AssemblyScanner>(); 
 
@@ -74,7 +73,15 @@ namespace StructureMap
         /// <param name="registry"></param>
         public void IncludeRegistry(Registry registry)
         {
-            alter = g => g.ImportRegistry(registry);
+            foreach (var scanner in registry.Scanners)
+            {
+                Scanners.Add(scanner);
+            }
+
+            foreach (var action in registry._actions)
+            {
+                _actions.Add(action);
+            }
         }
 
         /// <summary>
@@ -187,7 +194,6 @@ namespace StructureMap
         {
             return new GenericFamilyExpression(pluginType, lifecycle, this);
         }
-
 
         /// <summary>
         /// Shortcut to make StructureMap return the default object of U casted to T

--- a/src/StructureMap.Testing/Acceptance/nested_registry_declarations.cs
+++ b/src/StructureMap.Testing/Acceptance/nested_registry_declarations.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
+
 using NUnit.Framework;
-using StructureMap.Configuration.DSL;
 
 namespace StructureMap.Testing.Acceptance
 {
@@ -12,7 +12,8 @@ namespace StructureMap.Testing.Acceptance
         {
             var container = new Container(new ARegistry());
 
-            container.GetAllInstances<IWidget>().OrderBy(x => x.GetType().Name)
+            container.GetAllInstances<IWidget>()
+                .OrderBy(x => x.GetType().Name)
                 .Select(x => x.GetType())
                 .ShouldHaveTheSameElementsAs(typeof (AWidget), typeof (BWidget), typeof (CWidget),
                     typeof (DefaultWidget));
@@ -24,7 +25,8 @@ namespace StructureMap.Testing.Acceptance
             var container = new Container();
             container.Configure(x => x.IncludeRegistry<ARegistry>());
 
-            container.GetAllInstances<IWidget>().OrderBy(x => x.GetType().Name)
+            container.GetAllInstances<IWidget>()
+                .OrderBy(x => x.GetType().Name)
                 .Select(x => x.GetType())
                 .ShouldHaveTheSameElementsAs(typeof (AWidget), typeof (BWidget), typeof (CWidget),
                     typeof (DefaultWidget));

--- a/src/StructureMap.Testing/Acceptance/nested_registry_declarations.cs
+++ b/src/StructureMap.Testing/Acceptance/nested_registry_declarations.cs
@@ -29,6 +29,36 @@ namespace StructureMap.Testing.Acceptance
                 .ShouldHaveTheSameElementsAs(typeof (AWidget), typeof (BWidget), typeof (CWidget),
                     typeof (DefaultWidget));
         }
+
+        [Test]
+        public void get_instance_gets_most_recently_registered_type()
+        {
+            using (var container = new Container(new SecondRegistry()))
+            {
+                container.GetInstance<IWidget>()
+                    .IsType<BWidget>();
+            }
+        }
+    }
+
+    public class FirstRegistry : Registry
+    {
+        public FirstRegistry()
+        {
+            For<IWidget>()
+                .Use<AWidget>();
+        }
+    }
+
+    public class SecondRegistry : Registry
+    {
+        public SecondRegistry()
+        {
+            IncludeRegistry<FirstRegistry>();
+
+            For<IWidget>()
+                .Use<BWidget>();
+        }
     }
 
     public class ARegistry : Registry

--- a/src/StructureMap.Testing/Graph/AssemblyScannerTester.cs
+++ b/src/StructureMap.Testing/Graph/AssemblyScannerTester.cs
@@ -92,7 +92,6 @@ namespace StructureMap.Testing.Graph
             }
         }
 
-
         private void shouldHaveFamily<T>()
         {
             theGraph.Families.Has(typeof (T)).ShouldBeTrue();
@@ -102,7 +101,6 @@ namespace StructureMap.Testing.Graph
         {
             theGraph.Families.Has(typeof (T)).ShouldBeFalse();
         }
-
 
         private void shouldHaveFamilyWithSameName<T>()
         {


### PR DESCRIPTION
According to the [structuremap documentation](http://structuremap.github.io/registration/registry-dsl/), multiple uses of the ```For<TInterface>().Use<TImplementation>()``` syntax should result in the last call 'winning' and setting the default type.

When using nested registries, this does not seem to happen correctly (I have verified the order those statements are executed in the debugger).

This pull request adds a failing test that exemplifies this behavior. If my understanding of how this should work is flawed, please let me know.