### PR TITLE
Prevent null reference exception during Dispose.

### DIFF
--- a/src/StructureMap.Shared/Pipeline/LifecycleObjectCache.cs
+++ b/src/StructureMap.Shared/Pipeline/LifecycleObjectCache.cs
@@ -31,6 +31,10 @@ namespace StructureMap.Pipeline
 
         public void Eject(Type pluginType, Instance instance)
         {
+            // Prevent null reference exception.
+            if (pluginType.AssemblyQualifiedName == null)
+                return;
+
             var key = instance.InstanceKey(pluginType);
             _lock.MaybeWrite(() => {
                 if (!_objects.ContainsKey(key)) return;


### PR DESCRIPTION
I found that a NullReferenceException was thrown during Dispose when AssemblyQualifiedName is null. This is not a terribly elegant solution, but perhaps with some better understanding of why this scenario might come about, I could find a better one.