### PR TITLE
replace private user profile path with $(UserProfile)

### DIFF
--- a/src/StructureMap.Dotnet/StructureMap.Dotnet.nuget.targets
+++ b/src/StructureMap.Dotnet/StructureMap.Dotnet.nuget.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
-    <NuGetPackageRoot>C:\Users\jeremill\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
     <Import Project="$(NuGetPackageRoot)\NuSpec.ReferenceGenerator\1.0.0\build\dotnet\NuSpec.ReferenceGenerator.targets" Condition="Exists('$(NuGetPackageRoot)\NuSpec.ReferenceGenerator\1.0.0\build\dotnet\NuSpec.ReferenceGenerator.targets')" />


### PR DESCRIPTION
Use $(UserProfile) instead of explicit local user profile path.
This prevents Visual Studio from always changing the file locally.