### PR TITLE
Failing test for disposal of a nested container created from a named child container

### DIFF
--- a/src/StructureMap.Testing/Bugs/disposing_nested_container_created_from_profile.cs
+++ b/src/StructureMap.Testing/Bugs/disposing_nested_container_created_from_profile.cs
@@ -1,0 +1,42 @@
+﻿using Shouldly;
+using StructureMap.Testing.Acceptance;
+using Xunit;
+
+namespace StructureMap.Testing.Bugs
+{
+    public class disposing_nested_container_created_from_profile
+    {
+        private class ProfileRegistry : Registry
+        {
+            public ProfileRegistry()
+            {
+                Profile("my-profile", p => p.For<IService>().Use<AService>());
+            }
+        }
+
+        [Fact]
+        public void nested_container_from_profile()
+        {
+            var parent = new Container(_ =>
+            {
+                _.AddRegistry<ProfileRegistry>();
+            });
+
+            // Create a child container and override the
+            // IService registration
+            var child = parent.GetProfile("my-profile");
+
+            using (var nested = child.GetNestedContainer())
+            {
+                nested.GetInstance<IService>()
+                    .ShouldBeOfType<AService>();
+            }
+
+            using (var nested = child.GetNestedContainer())
+            {
+                nested.GetInstance<IService>()
+                    .ShouldBeOfType<AService>();
+            }
+        }
+    }
+}

--- a/src/StructureMap.Testing/StructureMap.Testing.csproj
+++ b/src/StructureMap.Testing/StructureMap.Testing.csproj
@@ -247,6 +247,7 @@
     <Compile Include="Bugs\ConnectImplementationsToTypesClosing_is_wonky_in_Registry_added_by_Configure.cs" />
     <Compile Include="Bugs\container_configuration_with_generics_inheritance.cs" />
     <Compile Include="Bugs\Defensive_check_for_public_ctors.cs" />
+    <Compile Include="Bugs\disposing_nested_container_created_from_profile.cs" />
     <Compile Include="Bugs\do_not_allow_policy_changes_in_nested_container_issue_284.cs" />
     <Compile Include="Bugs\do_not_allow_recursive_container_configure.cs" />
     <Compile Include="Bugs\EnumerableShouldGetAllValuesTester.cs" />


### PR DESCRIPTION
It seems that disposing of a nested container created from a profile clears all registrations of the profile. This PR contains a test for reproducing this issue 