### PR TITLE
Add inconspicuous link to the CI Server

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,7 +27,7 @@ to resolve nuget dependencies.
 
 Note:
 
-The StructureMap team uses Rake internally and on the CI server, but **Rake is no longer necessary in any way for developing with the StructureMap codebase**. 
+The StructureMap team uses Rake internally and on the [CI server](http://build.fubu-project.org/project.html?projectId=StructureMap3), but **Rake is no longer necessary in any way for developing with the StructureMap codebase**. 
 
 Please post any questions or bugs to the
 [StructureMap Users mailing list](https://groups.google.com/forum/#!forum/structuremap-users).


### PR DESCRIPTION
How would you feel about providing a link to the CI Server?  

**Considerations**
* People can hopefully figure out that you need to click _Log in as guest_, so decided not to add more instructions.
* The downside could be that making the CI server more visible may encourage people to lean on it's existence, i.e. not run tests locally.

Feel free to close this PR without explanation if you prefer to not include the link.