### PR TITLE
Bug: Ctor Policy and Decorators Issue - #537

### DIFF
--- a/src/StructureMap.Testing/Bugs/Bug_OpenGenericDecoratorsWithConstructorPolicyError.cs
+++ b/src/StructureMap.Testing/Bugs/Bug_OpenGenericDecoratorsWithConstructorPolicyError.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using StructureMap.Pipeline;
+using Xunit;
+
+namespace StructureMap.Testing.Bugs
+{
+	public class OpenGenericDecoratorsWithConstructorPolicy_Error
+	{
+		[Fact]
+		public void applies_the_constructor_policy_to_decorated_instances()
+		{
+			var container = new Container(_ =>
+			{
+				_.For(typeof(ICmdHandler<>)).DecorateAllWith(typeof(CmdDecorator<>));
+				_.Policies.Add<TestLoggerConstructorPolicy>();
+				_.Scan(a =>
+				{
+					a.TheCallingAssembly();
+					a.ConnectImplementationsToTypesClosing(typeof(ICmdHandler<>));
+				});
+			});
+
+			Console.WriteLine(container.WhatDoIHave());
+
+			var handler = container.GetInstance<ICmdHandler<TestCmd>>();
+		}
+	}
+
+	public interface ICmdHandler<T>
+	{
+		void Handle(T cmd);
+	}
+
+	public class CmdHandler : ICmdHandler<TestCmd>
+	{
+		public void Handle(TestCmd cmd)
+		{
+		}
+	}
+
+	public class TestCmd { }
+
+	public class CmdDecorator<T> : ICmdHandler<T>
+	{
+		private readonly ICmdHandler<T> _decorated;
+		private readonly ITestLogger _logger;
+
+		public CmdDecorator(ICmdHandler<T> decorated, ITestLogger logger)
+		{
+			_decorated = decorated;
+			_logger = logger;
+		}
+
+		public void Handle(T cmd)
+		{
+			_decorated.Handle(cmd);
+		}
+	}
+
+	public interface ITestLogger
+	{
+	}
+
+	public class TestLogger
+	{
+	}
+
+	public class TestLoggerConstructorPolicy : ConfiguredInstancePolicy
+	{
+		protected override void apply(Type pluginType, IConfiguredInstance instance)
+		{
+			var param = instance.Constructor.GetParameters().FirstOrDefault(x => x.ParameterType == typeof(ITestLogger));
+			if (param != null)
+			{
+				var logger = new TestLogger();
+				instance.Dependencies.AddForConstructorParameter(param, logger);
+			}
+			else
+			{
+				// Try to inject an ILogger via public-settable property.
+				var prop = instance.SettableProperties().FirstOrDefault(x => x.PropertyType == typeof(ITestLogger));
+				if (prop != null)
+				{
+					var logger = new TestLogger();
+					instance.Dependencies.AddForProperty(prop, logger);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Linked to #537 

Think the issue is in the BuildPlan class in the Build method which create the instance of the decorator. I have tried to follow the code but not had any luck. The issue could also be in the way in which you check whether to apply decorators by checking to see if they have already run against the instance.

My general thinking here is:

- Policies applied to actual instance
- Code tries to run policies against instance of decorator but is actually checking the "actual instance" instead. See's that policies have already been applied and then doesn't run them.

Thank you for any assistance you could provide on this one. 

