### PR TITLE
Allow handling of missing named instances from factory Func<string, T>

### DIFF
--- a/src/StructureMap.Testing/Pipeline/Lazy_and_Func_construction_strategy_Tester.cs
+++ b/src/StructureMap.Testing/Pipeline/Lazy_and_Func_construction_strategy_Tester.cs
@@ -122,6 +122,48 @@ namespace StructureMap.Testing.Pipeline
 
         // ENDSAMPLE
 
+        [Fact]
+        public void build_a_func_by_string_from_default()
+        {
+            var container = new Container(x =>
+            {
+                x.For<IWidget>().Add<ColorWidget>().Ctor<string>("color").Is("green").Named("green");
+                x.For<IWidget>().MissingNamedInstanceIs.ConstructedBy(c => new ColorWidget(c.RequestedName));
+            });
+
+            var func = container.GetInstance<Func<string, IWidget>>();
+            func("red").ShouldBeOfType<ColorWidget>().Color.ShouldBe("red");
+        }
+
+        [Fact]
+        public void build_a_func_by_string_from_parent()
+        {
+            var container = new Container(x =>
+            {
+                x.For<IWidget>().Add<ColorWidget>().Ctor<string>("color").Is("green").Named("green");
+                x.For<IWidget>().MissingNamedInstanceIs.ConstructedBy(c => new ColorWidget(c.RequestedName));
+                x.ForConcreteType<ConcreteWidgetUser>();
+            });
+
+            var parent = container.GetInstance<ConcreteWidgetUser>();
+            parent.Use("red").ShouldBeOfType<ColorWidget>().Color.ShouldBe("red");
+        }
+
+        public class ConcreteWidgetUser
+        {
+            private readonly Func<string, IWidget> _widgetFactory;
+
+            public ConcreteWidgetUser(Func<string, IWidget> widgetFactory)
+            {
+                _widgetFactory = widgetFactory;
+            }
+
+            public IWidget Use(string color)
+            {
+                return _widgetFactory(color);
+            }
+        }
+
         public class ConcreteClass
         {
         }

--- a/src/StructureMap/Graph/FuncBuildByNamePolicy.cs
+++ b/src/StructureMap/Graph/FuncBuildByNamePolicy.cs
@@ -44,7 +44,7 @@ namespace StructureMap.Graph
             var container = c.GetInstance<IContainer>();
             var instance = container.Model.Find<T>(name);
 
-            return instance.Lifecycle is UniquePerRequestLifecycle
+            return instance == null || instance.Lifecycle is UniquePerRequestLifecycle
                 ? container.GetInstance<T>(name)
                 : c.GetInstance<T>(name);
         })


### PR DESCRIPTION
Replaces #541.  Thanks for the work you do on such a great library!

I bumped into this NullReferenceException while attempting to use the handling of missing named instances with the Func<string, T> factory method that was constructor injected.

I ran `dotnet test src/StructureMap.Testing` after adding the tests to see the test failure and again after the code change to experience the tests passing.

Let me know if anything doesn't make sense or if you need any additional info.  

Affects code written for #354. 

Does not support customizing the lifecycle of the missing named instance.  Is this a deal breaker?

Not supported:
```
x.For<IWidget>().MissingNamedInstanceIs.ConstructedBy(c => new ColorWidget(c.RequestedName)).AlwaysUnique();
```
or
```
x.For<IWidget>().MissingNamedInstanceIs.ConstructedBy(c => new ColorWidget(c.RequestedName)).Singleton();
```