### PR TITLE
Force preview 2 tooling

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "projects": [ "src" ],
+  "sdk": {
+    "version": "1.0.0-preview2-003131"
+  }
+}


### PR DESCRIPTION
I believe preview 2 is the version that this project is currently using.  If preview 3 is installed, it breaks the build.  Adding a global.json specifying preview 2 tooling will keep the tooling for this project at that version until we are ready to update to the new version.

http://stackoverflow.com/a/40728854/5167537

I was pretty confused for awhile about .NET Core and tooling versions, but this [blog article](http://blog.tpcware.com/2016/12/multiple-versions-of-net-core-runtimes-and-sdk-tools-sxs-survive-guide/#facts) seems to explain the versioning scheme pretty well.