### PR TITLE
Ensure explicit arguments result in unique instances

### DIFF
--- a/src/StructureMap.Testing/Bugs/Bug_557_unique_instances_when_using_with.cs
+++ b/src/StructureMap.Testing/Bugs/Bug_557_unique_instances_when_using_with.cs
@@ -1,0 +1,31 @@
+﻿using Xunit;
+
+namespace StructureMap.Testing.Bugs
+{
+    public class Bug_557_unique_instances_when_using_with
+    {
+        [Fact]
+        public void should_return_unique_instances_when_using_With()
+        {
+            var root = new Container();
+            var nested1 = root.GetNestedContainer();
+            var nested2 = root.GetNestedContainer();
+
+            var i1_1 = nested1.With(new Arg()).GetInstance<Target>();
+            var i1_2 = nested1.With(new Arg()).GetInstance<Target>();
+            i1_1.ShouldNotBeTheSameAs(i1_2);
+
+            // Make sure that normal lifecycle was not affected by the other container
+            var i2_1 = nested2.GetInstance<Target>();
+            var i2_2 = nested2.GetInstance<Target>();
+            i2_1.ShouldBeTheSameAs(i2_2);
+        }
+
+        public class Target
+        {
+            public Target(Arg arg) {}
+        }
+
+        public class Arg { }
+    }
+}

--- a/src/StructureMap/SessionCache.cs
+++ b/src/StructureMap/SessionCache.cs
@@ -21,6 +21,7 @@ namespace StructureMap
         private readonly IDictionary<int, object> _cachedObjects = new Dictionary<int, object>();
         private readonly IDictionary<Type, object> _defaults = new Dictionary<Type, object>();
         private readonly IBuildSession _resolver;
+        private readonly bool _hasExplicitArguments;
 
         public SessionCache(IBuildSession resolver)
         {
@@ -30,7 +31,11 @@ namespace StructureMap
         public SessionCache(IBuildSession resolver, ExplicitArguments arguments)
             : this(resolver)
         {
-            if (arguments != null) _defaults = arguments.Defaults;
+            if (arguments != null)
+            {
+                _defaults = arguments.Defaults;
+                _hasExplicitArguments = _defaults.Any();
+            }
         }
 
         public object GetDefault(Type pluginType, IPipelineGraph pipelineGraph)
@@ -82,7 +87,7 @@ namespace StructureMap
                 return _resolver.BuildNewInSession(pluginType, instance);
             }
             
-            if (lifecycle is UniquePerRequestLifecycle)
+            if (lifecycle is UniquePerRequestLifecycle || _hasExplicitArguments)
             {
                 return _resolver.BuildUnique(pluginType, instance);
             }


### PR DESCRIPTION
This is a fix for #557. All tests are passing.

This was my first time digging through StructureMap's internals, so please let me know if this change could have unintended consequences!