### PR TITLE
Improve performance of LifecycleObjectCache

### DIFF
--- a/src/StructureMap/BuildSession.cs
+++ b/src/StructureMap/BuildSession.cs
@@ -17,8 +17,13 @@ namespace StructureMap
 
         private readonly Stack<Instance> _instances;
 
-        public BuildSession(IPipelineGraph pipelineGraph, string requestedName = null, ExplicitArguments args = null,
-            Stack<Instance> buildStack = null)
+        public BuildSession(IPipelineGraph pipelineGraph, string requestedName = null, ExplicitArguments args = null)
+            : this(pipelineGraph, requestedName, args, null)
+        {
+        }
+
+        private BuildSession(IPipelineGraph pipelineGraph, string requestedName, ExplicitArguments args,
+            Stack<Instance> buildStack)
         {
             this.pipelineGraph = pipelineGraph;
 
@@ -125,7 +130,7 @@ namespace StructureMap
 
         public object BuildNewInOriginalContext(Type pluginType, Instance instance)
         {
-            var session = new BuildSession(pipelineGraph.Root(), requestedName: instance.Name, buildStack: _instances);
+            var session = new BuildSession(pipelineGraph.Root(), instance.Name, null, _instances);
             return session.BuildNewInSession(pluginType, instance);
         }
 

--- a/src/StructureMap/Building/PushPopWrapper.cs
+++ b/src/StructureMap/Building/PushPopWrapper.cs
@@ -2,14 +2,13 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using StructureMap.Pipeline;
-using StructureMap.TypeRules;
 
 namespace StructureMap.Building
 {
     public static class PushPopWrapper
     {
-        public static readonly MethodInfo PushMethod = typeof (IBuildSession).GetMethod("Push");
-        public static readonly MethodInfo PopMethod = typeof (IBuildSession).GetMethod("Pop");
+        public static readonly MethodInfo PushMethod = typeof(IBuildSession).GetMethod(nameof(IBuildSession.Push));
+        public static readonly MethodInfo PopMethod = typeof(IBuildSession).GetMethod(nameof(IBuildSession.Pop));
 
         public static Expression WrapFunc(Type returnType, Instance instance, Expression inner)
         {


### PR DESCRIPTION
`LifecycleObjectCache` uses a global lock to update the object cache dictionary which is not very efficient since there is contention between unrelated objects. So the idea was to use more fine-grained locks with `ConcurrentDictionary`. The only problem with was the bi-directional dependency check.

I tried to dig the code history and it seems that initially the main class responsible for the bi-directional dependency check was `BuildSession` so I tried to fix it so that there is no need for additional check in `LifecycleObjectCache`. I did that by passing the current build stack in `BuildNewInOriginalContext` and it seems to be working fine - all tests are passing at least.

Once that was done, `LifecycleObjectCache` could be rewritten to use `ConcurrentDictionary`. I tested the updated implementation comparing the stable 4.4.5 version using the code from https://github.com/structuremap/structuremap/pull/572 and here are the results:
```
BenchmarkDotNet=v0.10.6, OS=Windows 10 Redstone 1 (10.0.14393)
Processor=Intel Core i5-4440 CPU 3.10GHz (Haswell), ProcessorCount=4
Frequency=3020347 Hz, Resolution=331.0878 ns, Timer=TSC
  [Host]     : Clr 4.0.30319.42000, 32bit LegacyJIT-v4.6.1648.0
  DefaultJob : Clr 4.0.30319.42000, 32bit LegacyJIT-v4.6.1648.0


                   Type |  Method |  Lifetime | ThreadsCount | ResolvedTypesCount |     Mean |    Error |    StdDev | Scaled | ScaledSD |
----------------------- |-------- |---------- |------------- |------------------- |---------:|---------:|----------:|-------:|---------:|
 StructureMap4Benchmark | Resolve | Singleton |            1 |                  5 | 726.1 ns | 4.626 ns |  4.327 ns |   1.00 |     0.00 |
  StructureMapBenchmark | Resolve | Singleton |            1 |                  5 | 661.9 ns | 5.593 ns |  5.232 ns |   0.91 |     0.01 |
 StructureMap4Benchmark | Resolve | Singleton |            2 |                  5 | 503.3 ns | 6.576 ns |  5.830 ns |   1.00 |     0.00 |
  StructureMapBenchmark | Resolve | Singleton |            2 |                  5 | 410.3 ns | 6.174 ns |  5.775 ns |   0.82 |     0.01 |
 StructureMap4Benchmark | Resolve | Singleton |            4 |                  5 | 461.2 ns | 8.569 ns |  8.016 ns |   1.00 |     0.00 |
  StructureMapBenchmark | Resolve | Singleton |            4 |                  5 | 260.4 ns | 5.178 ns |  8.361 ns |   0.56 |     0.02 |
 StructureMap4Benchmark | Resolve | Singleton |            6 |                  5 | 459.1 ns | 6.771 ns |  6.334 ns |   1.00 |     0.00 |
  StructureMapBenchmark | Resolve | Singleton |            6 |                  5 | 260.1 ns | 5.166 ns |  6.533 ns |   0.57 |     0.02 |
 StructureMap4Benchmark | Resolve | Transient |            1 |                  5 | 787.2 ns | 4.921 ns |  4.603 ns |   1.00 |     0.00 |
  StructureMapBenchmark | Resolve | Transient |            1 |                  5 | 764.9 ns | 6.294 ns |  5.887 ns |   0.97 |     0.01 |
 StructureMap4Benchmark | Resolve | Transient |            2 |                  5 |       NA |       NA |        NA |      ? |        ? |
  StructureMapBenchmark | Resolve | Transient |            2 |                  5 | 490.6 ns | 4.183 ns |  3.708 ns |      ? |        ? |
 StructureMap4Benchmark | Resolve | Transient |            4 |                  5 | 304.8 ns | 5.949 ns | 10.728 ns |   1.00 |     0.00 |
  StructureMapBenchmark | Resolve | Transient |            4 |                  5 | 299.6 ns | 5.926 ns |  8.870 ns |   0.98 |     0.04 |
 StructureMap4Benchmark | Resolve | Transient |            6 |                  5 |       NA |       NA |        NA |      ? |        ? |
  StructureMapBenchmark | Resolve | Transient |            6 |                  5 | 299.9 ns | 5.837 ns |  8.737 ns |      ? |        ? |
```

Note, that `NA` results from the stable version is due to the error reported as https://github.com/structuremap/structuremap/issues/573. Not sure why but it is not reproducible after the change done here, so it is either fixed as well or there there must be some other conditions to reproduce it for the code. BTW that issue is reproducible for SM 3.1.9.463 as well, so it must there for a long time now.