### PR TITLE
Nullable types

### DIFF
--- a/src/StructureMap.Testing/Pipeline/DependencyCollectionTester.cs
+++ b/src/StructureMap.Testing/Pipeline/DependencyCollectionTester.cs
@@ -62,7 +62,6 @@ namespace StructureMap.Testing.Pipeline
                 .ShouldBe(service1);
         }
 
-
         [Fact]
         public void can_override_and_last_one_in_wins()
         {
@@ -72,6 +71,20 @@ namespace StructureMap.Testing.Pipeline
 
             collection.FindByTypeOrName(typeof(IGateway), "foo")
                 .ShouldBeTheSameAs(gateway2);
+        }
+
+        [Fact]
+        public void nullable_type_found_by_underlying_type()
+        {
+            var collection = new DependencyCollection();
+            collection.Add("foo", 1);
+            collection.Add("bar", 1.1m);
+
+            collection.FindByTypeAndName(typeof(int?), "foo")
+                .ShouldBe(1);
+
+            collection.FindByTypeAndName(typeof(int?), "bar")
+                .ShouldBeNull();
         }
     }
 }

--- a/src/StructureMap.Testing/TypeExtensionsTester.cs
+++ b/src/StructureMap.Testing/TypeExtensionsTester.cs
@@ -128,6 +128,7 @@ namespace StructureMap.Testing
             typeof(string).IsSimple().ShouldBeTrue();
             typeof(BreedEnum).IsSimple().ShouldBeTrue();
             typeof(IGateway).IsSimple().ShouldBeFalse();
+            typeof(int?).IsSimple().ShouldBeTrue();
         }
 
         [Fact]

--- a/src/StructureMap/Pipeline/DependencyCollection.cs
+++ b/src/StructureMap/Pipeline/DependencyCollection.cs
@@ -89,7 +89,7 @@ namespace StructureMap.Pipeline
         {
             if (argumentType == null) return null;
 
-            var argument = _dependencies.LastOrDefault(x => x.Name == name && (x.Type == argumentType || (argumentType.IsNullable() && x.Type == argumentType.GetInnerTypeFromNullable())));
+            var argument = _dependencies.LastOrDefault(x => x.Name == name && (x.Type == argumentType || isMatchOnNullableInnerType(argumentType, x.Type)));
             if (argument == null && EnumerableInstance.IsEnumerable(argumentType))
             {
                 var elementType = EnumerableInstance.DetermineElementType(argumentType);
@@ -98,6 +98,11 @@ namespace StructureMap.Pipeline
             }
 
             return argument;
+        }
+
+        private bool isMatchOnNullableInnerType(Type argumentType, Type dependencyType)
+        {
+            return argumentType.IsNullable() && dependencyType == argumentType.GetInnerTypeFromNullable();
         }
 
         /// <summary>

--- a/src/StructureMap/Pipeline/DependencyCollection.cs
+++ b/src/StructureMap/Pipeline/DependencyCollection.cs
@@ -89,7 +89,7 @@ namespace StructureMap.Pipeline
         {
             if (argumentType == null) return null;
 
-            var argument = _dependencies.LastOrDefault(x => x.Name == name && x.Type == argumentType);
+            var argument = _dependencies.LastOrDefault(x => x.Name == name && (x.Type == argumentType || (argumentType.IsNullable() && x.Type == argumentType.GetInnerTypeFromNullable())));
             if (argument == null && EnumerableInstance.IsEnumerable(argumentType))
             {
                 var elementType = EnumerableInstance.DetermineElementType(argumentType);

--- a/src/StructureMap/TypeExtensions.cs
+++ b/src/StructureMap/TypeExtensions.cs
@@ -253,7 +253,7 @@ namespace StructureMap.TypeRules
         {
             if (type == null) return false;
 
-            return type.GetTypeInfo().IsPrimitive || IsString(type) || type.GetTypeInfo().IsEnum;
+            return type.GetTypeInfo().IsPrimitive || IsString(type) || type.GetTypeInfo().IsEnum || IsNullable(type);
         }
 
         public static bool IsInterfaceOrAbstract(this Type type)


### PR DESCRIPTION
Updates to have StructureMap treat nullable types like simple types, so it will fail right away if they are missing nullable dependencies and so that they can be easily passed as explicit arguments.