### PR TITLE
Bug #539 - Thread local lifecycle cache should be container specific

### DIFF
--- a/src/StructureMap.Testing/Bugs/Bug_539_Thread_local_child_container_context_is_root_container.cs
+++ b/src/StructureMap.Testing/Bugs/Bug_539_Thread_local_child_container_context_is_root_container.cs
@@ -1,0 +1,46 @@
+﻿using Shouldly;
+using StructureMap.Pipeline;
+using Xunit;
+
+namespace StructureMap.Testing.Bugs
+{
+    public class Bug_539_Thread_local_child_container_context_is_root_container
+    {
+        [Fact]
+        public void thread_local_container_context_should_match_container_instance()
+        {
+            var container = new Container();
+            container.Configure(x =>
+            {
+                x.For<ISession>().LifecycleIs(Lifecycles.ThreadLocal).Use(c => new Session(c.GetInstance<IContainer>()));
+            });
+
+            {
+                var child = container.GetNestedContainer();
+                child.Configure(x =>
+                {
+                    x.For<ISession>().Use<Session>();
+                });
+
+                container.GetInstance<ISession>().Container.ShouldBe(container);
+                child.GetInstance<ISession>().Container.ShouldNotBe(container);
+                child.GetInstance<ISession>().Container.ShouldBe(child);
+            }
+        }
+
+        public interface ISession
+        {
+            IContainer Container { get; }
+        }
+
+        public class Session : ISession
+        {
+            public IContainer Container { get; }
+
+            public Session(IContainer container)
+            {
+                Container = container;
+            }
+        }
+    }
+}

--- a/src/StructureMap/Pipeline/ThreadLocalStorageLifecycle.cs
+++ b/src/StructureMap/Pipeline/ThreadLocalStorageLifecycle.cs
@@ -4,7 +4,7 @@ namespace StructureMap.Pipeline
 {
     public class ThreadLocalStorageLifecycle : LifecycleBase
     {
-        private static readonly ThreadLocal<IObjectCache> Cache = new ThreadLocal<IObjectCache>(() => new LifecycleObjectCache());
+        private static readonly ThreadLocal<IObjectCache> Cache = new ThreadLocal<IObjectCache>(() => new ContainerSpecificObjectCache());
 
         public override void EjectAll(ILifecycleContext context)
         {


### PR DESCRIPTION
Sorry for the long delay in getting this one in, @schotime and I had worked around it and completely forgotten about creating a pull request for the fix.

This fixes the issue where a nested container would build an instance using the root container if the lifecycle was ThreadLocal.
Appears to be caused by the build plan being cached for that object over the entire lifecycle rather than the lifecycle and container. Swapping the cache out for the container specific cache appears to fix the problem.