### PR TITLE
Add info about v4.5 not working on Xamarin iOS

### DIFF
--- a/documentation/get-structuremap.md
+++ b/documentation/get-structuremap.md
@@ -12,7 +12,9 @@ The current version of StructureMap will always be available on [Nuget](https://
 
 The original `StructureMap.dll` has been broken up into a couple pieces. The main assembly will be targeting PCL compliance thanks to the diligent efforts of [Frank Quednau](https://twitter.com/fquednau), and that means that anything to do with ASP.Net or falls outside of the PCL core has been devolved into separate assemblies and eventually into different Nuget packages. This means that StructureMap 3.* will *theoretically* support WP8 and other versions of .Net for the very first time.
 
-At this point StructureMap 3.* has been used on .Net 4, 4.5, WP8, and WP8.1. Nobody in the core StructureMap team is currently working with Xamarin mobile runtimes, but we are interested in verifying StructureMap on new platforms if any volunteers are interested in helping us out.
+At this point StructureMap 3.* has been used on .Net 4, 4.5, WP8, and WP8.1. 
+
+StructureMap 4.5+ will not work on Xamarin iOS because it depends on System.Reflection.Emit, [which is not available in MonoTouch](https://developer.xamarin.com/guides/ios/advanced_topics/limitations/). StructureMap 4.4 works for at least basic scenarios on that platform. Nobody in the core StructureMap team is currently working with Xamarin mobile runtimes, but we are interested in verifying StructureMap on new platforms if any volunteers are interested in helping us out.
 
 ## Binaries
 


### PR DESCRIPTION
On Xamarin iOS, trying to resolve an instance results in the following exception message. @jeremydmiller suggested that backing off to a version < 4.5 would work because that was when System.Reflection.Emit was introduced as part of FastExpressionCompiler. I was able to confirm this works. 

```
{System.PlatformNotSupportedException: Operation is not supported on this platform.
  at System.Reflection.Emit.DynamicMethod..ctor (System.String name, System.Type returnType, System.Type[] parameterTypes, System.Type owner, System.Boolean skipVisibility) [0x00006] in <36d2e2e4d37749c6a744327e23a7f3c8>:0 
  at StructureMap.Util.ExpressionCompiler.GetDynamicMethod (System.Type[] paramTypes, System.Type returnType, StructureMap.Util.ExpressionCompiler+ClosureInfo closureInfo) [0x00003] in <4103a3d0646144ecaa3c1fdcdd2cd9cf>:0 
  at StructureMap.Util.ExpressionCompiler.TryCompile (StructureMap.Util.ExpressionCompiler+ClosureInfo& closureInfo, System.Type delegateType, System.Type[] paramTypes, System.Type returnType, System.Linq.Expressions.Expression bodyExpr, System.Collections.Generic.IList`1[T] paramExprs) [0x00019] in <4103a3d0646144ecaa3c1fdcdd2cd9cf>:0 
  at StructureMap.Util.ExpressionCompiler.TryCompile[TDelegate] (System.Linq.Expressions.Expression bodyExpr, System.Collections.Generic.IList`1[T] paramExprs, System.Type[] paramTypes, System.Type returnType) [0x00002] in <4103a3d0646144ecaa3c1fdcdd2cd9cf>:0 
  at StructureMap.Util.ExpressionCompiler.TryCompile[TDelegate] (System.Linq.Expressions.LambdaExpression lambdaExpr) [0x0001e] in <4103a3d0646144ecaa3c1fdcdd2cd9cf>:0 
  at StructureMap.Util.ExpressionCompiler.Compile[TDelegate] (System.Linq.Expressions.LambdaExpression lambdaExpr) [0x00000] in <4103a3d0646144ecaa3c1fdcdd2cd9cf>:0 
  at StructureMap.Building.BuildPlan.ToDelegate () [0x0010b] in <4103a3d0646144ecaa3c1fdcdd2cd9cf>:0 
  at StructureMap.Building.BuildPlan..ctor (System.Type pluginType, StructureMap.Pipeline.Instance instance, StructureMap.Building.IDependencySource inner, StructureMap.Policies policies, System.Collections.Generic.IEnumerable`1[T] interceptors) [0x0003a] in <4103a3d0646144ecaa3c1fdcdd2cd9cf>:0 
  at StructureMap.Pipeline.Instance.buildPlan (System.Type pluginType, StructureMap.Policies policies) [0x0001b] in <4103a3d0646144ecaa3c1fdcdd2cd9cf>:0 }
    base: {System.NotSupportedException}
```

This PR adds info on the problem & workaround to the documentation website.