### PR TITLE
Allow to filter assemblies by path during the scan

### DIFF
--- a/src/StructureMap.Testing/Graph/AssemblyScannerTester.cs
+++ b/src/StructureMap.Testing/Graph/AssemblyScannerTester.cs
@@ -153,10 +153,28 @@ namespace StructureMap.Testing.Graph
         }
 
         [Fact]
+        public void scan_all_assemblies_in_a_folder_with_path_filter()
+        {
+            Scan(x => x.AssembliesFromPath(assemblyScanningFolder, path => !path.Contains("Widget5")));
+            shouldNotHaveFamilyWithSameName<IInterfaceInWidget5>();
+            shouldHaveFamilyWithSameName<IWorker>();
+            shouldNotHaveFamilyWithSameName<IDefinedInExe>();
+        }
+
+        [Fact]
         public void scan_all_assemblies_in_application_base_directory()
         {
             Scan(x => x.AssembliesFromApplicationBaseDirectory());
             shouldHaveFamilyWithSameName<IInterfaceInWidget5>();
+            shouldHaveFamilyWithSameName<IWorker>();
+            shouldNotHaveFamilyWithSameName<IDefinedInExe>();
+        }
+
+        [Fact]
+        public void scan_all_assemblies_in_application_base_directory_with_path_filter()
+        {
+            Scan(x => x.AssembliesFromApplicationBaseDirectory(path => !path.Contains("Widget5")));
+            shouldNotHaveFamilyWithSameName<IInterfaceInWidget5>();
             shouldHaveFamilyWithSameName<IWorker>();
             shouldNotHaveFamilyWithSameName<IDefinedInExe>();
         }
@@ -174,6 +192,16 @@ namespace StructureMap.Testing.Graph
             shouldHaveFamilyWithSameName<IDefinedInExe>();
         }
 
+        [Fact]
+        public void scan_all_assemblies_in_a_folder_including_exe_with_path_filter()
+        {
+            Scan(x => x.AssembliesAndExecutablesFromPath(assemblyScanningFolder, path => !path.Contains("Widget5")));
+
+            shouldNotHaveFamilyWithSameName<IInterfaceInWidget5>();
+            shouldHaveFamilyWithSameName<IWorker>();
+            shouldHaveFamilyWithSameName<IDefinedInExe>();
+        }
+
 
         [Fact]
         public void scan_all_assemblies_in_application_base_directory_including_exe()
@@ -181,6 +209,16 @@ namespace StructureMap.Testing.Graph
             Scan(x => x.AssembliesAndExecutablesFromApplicationBaseDirectory());
 
             shouldHaveFamilyWithSameName<IInterfaceInWidget5>();
+            shouldHaveFamilyWithSameName<IWorker>();
+            shouldHaveFamilyWithSameName<IDefinedInExe>();
+        }
+
+        [Fact]
+        public void scan_all_assemblies_in_application_base_directory_including_exe_with_path_filter()
+        {
+            Scan(x => x.AssembliesAndExecutablesFromApplicationBaseDirectory(path => !path.Contains("Widget5")));
+
+            shouldNotHaveFamilyWithSameName<IInterfaceInWidget5>();
             shouldHaveFamilyWithSameName<IWorker>();
             shouldHaveFamilyWithSameName<IDefinedInExe>();
         }

--- a/src/StructureMap/Graph/AssemblyScanner.cs
+++ b/src/StructureMap/Graph/AssemblyScanner.cs
@@ -187,7 +187,7 @@ namespace StructureMap.Graph
         {
             return _assemblies.Any();
         }
-
+        
 
         public void TheCallingAssembly()
         {
@@ -205,15 +205,22 @@ namespace StructureMap.Graph
 
         public void AssembliesFromApplicationBaseDirectory()
         {
-            AssembliesFromApplicationBaseDirectory(a => true);
+            AssembliesFromApplicationBaseDirectory((Assembly a) => true);
         }
 
         public void AssembliesFromApplicationBaseDirectory(Func<Assembly, bool> assemblyFilter)
         {
-            var assemblies = AssemblyFinder.FindAssemblies(assemblyFilter, txt =>
+            var assemblies = AssemblyFinder.FindAssemblies(assemblyFilter, includeExeFiles: false);
+
+            foreach (var assembly in assemblies)
             {
-                Console.WriteLine("StructureMap could not load assembly from file " + txt);
-            }, includeExeFiles: false);
+                Assembly(assembly);
+            }
+        }
+
+        public void AssembliesFromApplicationBaseDirectory(Func<string, bool> pathFilter)
+        {
+            var assemblies = AssemblyFinder.FindAssemblies(null, includeExeFiles: false, pathFilter: pathFilter);
 
             foreach (var assembly in assemblies)
             {
@@ -224,15 +231,24 @@ namespace StructureMap.Graph
         /// <summary>
         /// Choosing option will direct StructureMap to *also* scan files ending in '*.exe'
         /// </summary>
-        /// <param name="scanner"></param>
         /// <param name="assemblyFilter"></param>
-        /// <param name="includeExeFiles"></param>
         public void AssembliesAndExecutablesFromApplicationBaseDirectory(Func<Assembly, bool> assemblyFilter = null)
         {
-            var assemblies = AssemblyFinder.FindAssemblies(assemblyFilter, txt =>
+            var assemblies = AssemblyFinder.FindAssemblies(assemblyFilter, includeExeFiles: true);
+
+            foreach (var assembly in assemblies)
             {
-                Console.WriteLine("StructureMap could not load assembly from file " + txt);
-            }, includeExeFiles: true);
+                Assembly(assembly);
+            }
+        }
+
+        /// <summary>
+        /// Choosing option will direct StructureMap to *also* scan files ending in '*.exe'
+        /// </summary>
+        /// <param name="pathFilter"></param>
+        public void AssembliesAndExecutablesFromApplicationBaseDirectory(Func<string, bool> pathFilter = null)
+        {
+            var assemblies = AssemblyFinder.FindAssemblies(null, includeExeFiles: true, pathFilter: pathFilter);
 
             foreach (var assembly in assemblies)
             {
@@ -288,6 +304,36 @@ namespace StructureMap.Graph
             {
                 Console.WriteLine("StructureMap could not load assembly from file " + txt);
             }, includeExeFiles: false).Where(assemblyFilter);
+
+
+            foreach (var assembly in assemblies)
+            {
+                Assembly(assembly);
+            }
+        }
+
+        public void AssembliesAndExecutablesFromPath(string path,
+            Func<string, bool> pathFilter)
+        {
+            var assemblies = AssemblyFinder.FindAssemblies(path, txt =>
+            {
+                Console.WriteLine("StructureMap could not load assembly from file " + txt);
+            }, includeExeFiles: true, pathFilter: pathFilter);
+
+
+            foreach (var assembly in assemblies)
+            {
+                Assembly(assembly);
+            }
+        }
+
+        public void AssembliesFromPath(string path,
+            Func<string, bool> pathFilter)
+        {
+            var assemblies = AssemblyFinder.FindAssemblies(path, txt =>
+            {
+                Console.WriteLine("StructureMap could not load assembly from file " + txt);
+            }, includeExeFiles: false, pathFilter: pathFilter);
 
 
             foreach (var assembly in assemblies)

--- a/src/StructureMap/Graph/IAssemblyScanner.cs
+++ b/src/StructureMap/Graph/IAssemblyScanner.cs
@@ -141,24 +141,24 @@ namespace StructureMap.Graph
         ConfigureConventionExpression SingleImplementationsOfInterface();
 
         void TheCallingAssembly();
+
         void AssembliesFromApplicationBaseDirectory();
         void AssembliesFromApplicationBaseDirectory(Func<Assembly, bool> assemblyFilter);
+        void AssembliesFromApplicationBaseDirectory(Func<string, bool> pathFilter);
 
         /// <summary>
         /// Choosing option will direct StructureMap to *also* scan files ending in '*.exe'
         /// </summary>
-        /// <param name="scanner"></param>
         /// <param name="assemblyFilter"></param>
-        /// <param name="includeExeFiles"></param>
         void AssembliesAndExecutablesFromApplicationBaseDirectory(Func<Assembly, bool> assemblyFilter = null);
+        void AssembliesAndExecutablesFromApplicationBaseDirectory(Func<string, bool> pathFilter);
 
         void AssembliesAndExecutablesFromPath(string path);
+        void AssembliesAndExecutablesFromPath(string path, Func<Assembly, bool> assemblyFilter);
+        void AssembliesAndExecutablesFromPath(string path, Func<string, bool> pathFilter);
+
         void AssembliesFromPath(string path);
-
-        void AssembliesAndExecutablesFromPath(string path,
-            Func<Assembly, bool> assemblyFilter);
-
-        void AssembliesFromPath(string path,
-            Func<Assembly, bool> assemblyFilter);
+        void AssembliesFromPath(string path, Func<Assembly, bool> assemblyFilter);
+        void AssembliesFromPath(string path, Func<string, bool> pathFilter);
     }
 }


### PR DESCRIPTION
Hi,
I found very annoying to see in the output of the debugger "**BadImageFormatException**"s when using policy like "**AssembliesAndExecutablesFromApplicationBaseDirectory**" during the scan.
This is due to the fact I have some unmanaged assemblies, and structuremap try to load them anyway (and fail). I guess this also slows down the entire scan process.

So this little edit is just to enable the use of a Func that is meant to decide whether or not take into account a given assembly in a given path.

Please note two things:

1. I found this overload of the AssemblyFinder method: 
`FindAssemblies(Func<Assembly, bool> filter, Action<string> onDirectoryFound = null, bool includeExeFiles=false)` that accept the action "onDirectoryFound" but actually ignores that action. I replaced that action with the Func of above.

2. The following methods: 
   - **AssembliesFromApplicationBaseDirectory**
   - **AssembliesAndExecutablesFromApplicationBaseDirectory**

   Were calling the wrong overload of the "FindAssembly" methods. 
I guess the right overload to call (seeing the body of the method) was this:
`IEnumerable<Assembly> FindAssemblies(string assemblyPath, Action<string> logFailure, bool includeExeFiles, Func<string, bool> pathFilter = null)`
But instead they call this:
`FindAssemblies(Func<Assembly, bool> filter, Action<string> onDirectoryFound = null, bool includeExeFiles=false)` (the overload of the point 1)

Thanks