### PR TITLE
Fix incorrect XML doc

### DIFF
--- a/src/StructureMap/Configuration/DSL/Expressions/GenericFamilyExpression.cs
+++ b/src/StructureMap/Configuration/DSL/Expressions/GenericFamilyExpression.cs
@@ -218,7 +218,7 @@ namespace StructureMap.Configuration.DSL.Expressions
         }
 
         /// <summary>
-        /// Convenience method to mark a PluginFamily as a Singleton
+        /// Convenience method to mark a PluginFamily as ContainerScoped
         /// </summary>
         /// <returns></returns>
         public GenericFamilyExpression ContainerScoped()


### PR DESCRIPTION
XML doc summary of GenericFamilyExpression.ContainerScoped mentioned Singleton instead of ContainerScoped.