### PR TITLE
Don't create new instances when trying to remove them

### DIFF
--- a/src/StructureMap/Pipeline/LazyLifecycleObjectCacheExtensions.cs
+++ b/src/StructureMap/Pipeline/LazyLifecycleObjectCacheExtensions.cs
@@ -32,7 +32,7 @@ namespace StructureMap.Pipeline
             LazyLifecycleObject<TValue> lazy;
             var result = cache.TryRemove(key, out lazy);
 
-            value = result ? lazy.Value : default(TValue);
+            value = result && lazy.IsValueCreated ? lazy.Value : default(TValue);
 
             return result;
         }


### PR DESCRIPTION
We had an issue where instances were created during container.Dispose(). 

We are using a Nested Container (a request container in a MVC application) which is creating instances with lambda as described in http://structuremap.github.io/the-container/lambdas/.

Ie our Registry has definitions like

```
For<ConcreteType>.Use("name", context => {
    // ... 
    return new ConcreteType();
});
```

We noticed that instances were created during NestedContainer.Dispose().

We tracked this down to `LazyLifecycleObjectCacheExtensions.TryRemove`. If the LazyLifecycleObject hasn't been used, it will be created here. Is that the intended behavior?

This PR will return the instance if it has been created otherwise the default value for the type.

I tried to write a test for this but I need some help where to start.