### PR TITLE
fix: ArgumentNullException with ConnectImplementationsToTypesClosing

### DIFF
--- a/src/StructureMap/TypeExtensions.cs
+++ b/src/StructureMap/TypeExtensions.cs
@@ -145,7 +145,9 @@ namespace StructureMap.TypeRules
                 yield return TPluggedType.GetTypeInfo().BaseType;
             }
 
-            if (TPluggedType.GetTypeInfo().BaseType == typeof(object)) yield break;
+            if (TPluggedType.GetTypeInfo().BaseType == typeof(object)
+                || TPluggedType == typeof(object)
+                ) yield break;
 
             foreach (var interfaceType in rawFindInterfacesThatCloses(TPluggedType.GetTypeInfo().BaseType, templateType))
             {


### PR DESCRIPTION
We have an issue while initializing the container :

`
Parameter name: type) (Value cannot be null.
Parameter name: type) ---> System.ArgumentNullException: Value cannot be null.
Parameter name: type
   at System.Reflection.IntrospectionExtensions.GetTypeInfo(Type type)
   at StructureMap.TypeRules.TypeExtensions.IsConcrete(Type type)
   at StructureMap.TypeRules.TypeExtensions.<rawFindInterfacesThatCloses>d__16.MoveNext()
   at StructureMap.TypeRules.TypeExtensions.<rawFindInterfacesThatCloses>d__16.MoveNext()
   at System.Linq.Enumerable.DistinctIterator`1.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source)
   at StructureMap.Graph.GenericConnectionScanner.<ScanTypes>b__5_0(Type type)
   at StructureMap.StringExtensions.Each[T](IEnumerable`1 enumerable, Action`1 action)
   at StructureMap.Graph.GenericConnectionScanner.ScanTypes(TypeSet types, Registry registry)
   at StructureMap.StringExtensions.Each[T](IEnumerable`1 enumerable, Action`1 action)
   at StructureMap.Graph.AssemblyScanner.<ScanForTypes>b__33_1(Task`1 t)
   at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2.InnerInvoke()
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
   --- End of inner exception stack trace ---
   at System.ThrowHelper.ThrowAggregateException(List`1 exceptions)
   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at StructureMap.PluginGraphBuilder.RunConfigurations()
   at StructureMap.PluginGraphBuilder.RunConfigurations()
   at StructureMap.PipelineGraph.Configure(Action`1 configure)
   at StructureMap.Container.Configure(Action`1 configure)
`

We had the issue with the following code :

```csharp
public class HandlerRegistry : Registry
{
	public HandlerRegistry()
	{
		Scan(scanner =>
		{
			scanner.TheCallingAssembly();
			scanner.AssembliesFromApplicationBaseDirectory();
			scanner.AddAllTypesOf(typeof(IRequestHandler<,>));
			scanner.ConnectImplementationsToTypesClosing(typeof(IRequestHandler<,>));
		});
	}
}
```

Basically, with .netcore you get System.Private.CoreLib assembly in your base path which contains System.Object which is checked against the closing type. 

Exception is cause by the fact that System.Object doesn't have a BaseType 