### PR TITLE
Update layout.htm

### DIFF
--- a/documentation/layout.htm
+++ b/documentation/layout.htm
@@ -114,8 +114,8 @@
 
 
     <foot>
-        <script type='text/javascript' src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-        <script type='text/javascript' src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+        <script type='text/javascript' src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+        <script type='text/javascript' src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 
         <[script:content/embed.js]>
         <[script:content/prism.js]>


### PR DESCRIPTION
When accessing documentation website eg https://structuremap.github.io/object-lifecycle/supported-lifecycles/
the browser fails to load jquery due to mixed content. Thus, the search bar does not work.

Proposed solution: use the protocol-relative url in script sections.