### PR TITLE
Expanded usages of Type.GetConstructors() to include internal

### DIFF
--- a/src/StructureMap/Attributes/DefaultConstructorAttribute.cs
+++ b/src/StructureMap/Attributes/DefaultConstructorAttribute.cs
@@ -17,13 +17,13 @@ namespace StructureMap
         /// Examines a System.Type object and determines the ConstructorInfo to use in creating
         /// instances of the Type
         /// </summary>
-        /// <param name="ExportedType"></param>
+        /// <param name="exportedType"></param>
         /// <returns></returns>
-        public static ConstructorInfo GetConstructor(Type ExportedType)
+        public static ConstructorInfo GetConstructor(Type exportedType)
         {
             ConstructorInfo returnValue = null;
 
-            foreach (var constructor in ExportedType.GetConstructors())
+            foreach (var constructor in exportedType.GetPublicAndInternalConstructors())
             {
                 var atts = constructor.GetCustomAttributes(typeof (DefaultConstructorAttribute), true);
 

--- a/src/StructureMap/Pipeline/ConstructorInstance.cs
+++ b/src/StructureMap/Pipeline/ConstructorInstance.cs
@@ -38,16 +38,16 @@ namespace StructureMap.Pipeline
                 throw new ArgumentOutOfRangeException("concreteType", concreteType,"Only concrete types can be built by ConstructorInstance.");
             }
 
-            if (!concreteType.GetConstructors().Any())
+            if (!concreteType.GetPublicAndInternalConstructors().Any())
             {
                 throw new ArgumentOutOfRangeException(
                     "{0} must have at least one public constructor to be plugged in by StructureMap".ToFormat(
                         concreteType.GetFullName()));
             }
 
-            if (concreteType.GetConstructors().Count() == 1)
+            if (concreteType.GetPublicAndInternalConstructors().Count() == 1)
             {
-                Constructor = concreteType.GetConstructors().Single();
+                Constructor = concreteType.GetPublicAndInternalConstructors().Single();
             }
 
             PluggedType = concreteType;

--- a/src/StructureMap/Pipeline/ConstructorSelector.cs
+++ b/src/StructureMap/Pipeline/ConstructorSelector.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using StructureMap.Graph;
+using StructureMap.TypeRules;
 
 namespace StructureMap.Pipeline
 {
@@ -58,7 +59,7 @@ namespace StructureMap.Pipeline
     {
         public ConstructorInfo Find(Type pluggedType, DependencyCollection dependencies, PluginGraph graph)
         {
-            return pluggedType.GetConstructors().FirstOrDefault();
+            return pluggedType.GetPublicAndInternalConstructors().FirstOrDefault();
         }
     }
 }

--- a/src/StructureMap/Pipeline/GreediestConstructorSelector.cs
+++ b/src/StructureMap/Pipeline/GreediestConstructorSelector.cs
@@ -10,8 +10,7 @@ namespace StructureMap.Pipeline
     {
         public ConstructorInfo Find(Type pluggedType, DependencyCollection dependencies, PluginGraph graph)
         {
-            return pluggedType
-                .GetConstructors()
+            return pluggedType.GetPublicAndInternalConstructors()
                 .Where(x => !HasMissingPrimitives(x, dependencies))
                 .OrderByDescending(x => x.GetParameters().Count())
                 .FirstOrDefault();

--- a/src/StructureMap/Registry.cs
+++ b/src/StructureMap/Registry.cs
@@ -462,7 +462,7 @@ namespace StructureMap
             if (type == typeof (Registry)) return false;
             if (type == typeof (ConfigurationExpression)) return false;
 
-            var constructors = type.GetConstructors();
+            var constructors = type.GetPublicAndInternalConstructors();
             if (constructors.Count() == 1 && !constructors.Single().GetParameters().Any())
             {
                 if (all.Any(x => x.GetType() == type)) return true;

--- a/src/StructureMap/TypeExtensions.cs
+++ b/src/StructureMap/TypeExtensions.cs
@@ -290,7 +290,31 @@ namespace StructureMap.TypeRules
 
         public static bool HasConstructors(this Type type)
         {
-            return type.GetConstructors().Any();
+            return type.GetPublicAndInternalConstructors().Any();
+        }
+        
+        /// <summary>
+        /// Returns all public and internal (but not internal protected) constructors
+        /// for <paramref name="type"/>,
+        /// but only if <paramref name="type"/> is a non-abstract class.
+        /// </summary>
+        /// <returns>
+        /// An array of zero, or more, <see cref="ConstructorInfo"/> instances.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="type"/> is null.
+        /// </exception>
+        public static ConstructorInfo[] GetPublicAndInternalConstructors(this Type type)
+        {
+            if (type == null) throw new ArgumentNullException("type");
+            
+            if (type.IsInterfaceOrAbstract()) return new ConstructorInfo[0];
+            
+            return type.GetConstructors(BindingFlags.Public
+                                        | BindingFlags.NonPublic
+                                        | BindingFlags.Instance).Where(ci =>
+                ci.IsPublic /* public */
+                || ci.IsAssembly /* internal, but not internal protected */).ToArray();
         }
 
         public static bool IsVoidReturn(this Type type)


### PR DESCRIPTION
Note that this does not cover Type.GetConstructor(Type[]). Those weren't required for the consuming software (LCModel), and references to Type.GetConstructor(BindingFlags, Binder, Type[], ParameterModifier[]) were failing for some reason.